### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ python tools/eval.py -n  yolox-s -c yolox_s.pth.tar -b 1 -d 1 --conf 0.001 --fp1
 
 1.  [ONNX export and an ONNXRuntime](./demo/ONNXRuntime)
 2.  [TensorRT in C++ and Python](./demo/TensorRT)
-3.  [NCNN in C++ and Java](./demo/ncnn)
+3.  [ncnn in C++ and Java](./demo/ncnn)
 4.  [OpenVINO in C++ and Python](./demo/OpenVINO)
 
 ## Cite YOLOX

--- a/demo/ncnn/android/README.md
+++ b/demo/ncnn/android/README.md
@@ -1,4 +1,4 @@
-# YOLOX-Android-NCNN
+# YOLOX-Android-ncnn
 
 Andoird app of YOLOX object detection base on [ncnn](https://github.com/Tencent/ncnn)
 

--- a/demo/ncnn/android/README.md
+++ b/demo/ncnn/android/README.md
@@ -1,6 +1,6 @@
 # YOLOX-Android-NCNN
 
-Andoird app of YOLOX object detection base on [NCNN](https://github.com/Tencent/ncnn)
+Andoird app of YOLOX object detection base on [ncnn](https://github.com/Tencent/ncnn)
 
 
 ## Tutorial

--- a/demo/ncnn/cpp/README.md
+++ b/demo/ncnn/cpp/README.md
@@ -1,4 +1,4 @@
-# YOLOX-CPP-NCNN
+# YOLOX-CPP-ncnn
 
 Cpp file compile of YOLOX object detection base on [ncnn](https://github.com/Tencent/ncnn).
 


### PR DESCRIPTION
The official name of ncnn is lowercase, not uppercase.