### PR TITLE
refactor(utils): call apex in is_parallel

### DIFF
--- a/yolox/utils/ema.py
+++ b/yolox/utils/ema.py
@@ -4,13 +4,14 @@
 import math
 from copy import deepcopy
 
-import apex
 import torch
 import torch.nn as nn
 
 
 def is_parallel(model):
     """check if model is in parallel mode."""
+    import apex
+
     parallel_type = (
         nn.parallel.DataParallel,
         nn.parallel.DistributedDataParallel,


### PR DESCRIPTION
Hi, this can help people to do the inference without installing `apex`, especially when the user does not need to train a new model.