### PR TITLE
Potential Bug fixes and Docs update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 ### Linux ###
 *~
 
+# demo output directory
+YOLOX_outputs/
+
 # temporary files which can be created if a process still has a handle open of a deleted file
 .fuse_hidden*
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 ### Linux ###
 *~
 
-# demo output directory
+# user experiments directory
 YOLOX_outputs/
+datasets/
 
 # temporary files which can be created if a process still has a handle open of a deleted file
 .fuse_hidden*

--- a/README.md
+++ b/README.md
@@ -59,20 +59,6 @@ Step3. Install [pycocotools](https://github.com/cocodataset/cocoapi).
 pip3 install cython; pip3 install 'git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI'
 ```
 
-Step4. Install [OpenCV](https://github.com/opencv/opencv-python)
-
-- There are many ways to install `opencv-python`, if you are using pip then use below command
-
-  ````shell
-  pip3 install opencv-python
-  ````
-
-- If you are on linux (Ubuntu) you can use `apt` to install it
-
-  ````shell
-  sudo apt-get install -y python3-opencv
-  ````
-
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ Step3. Install [pycocotools](https://github.com/cocodataset/cocoapi).
 pip3 install cython; pip3 install 'git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI'
 ```
 
+Step4. Install [OpenCV](https://github.com/opencv/opencv-python)
+
+- There are many ways to install `opencv-python`, if you are using pip then use below command
+
+  ````shell
+  pip3 install opencv-python
+  ````
+
+- If you are on linux (Ubuntu) you can use `apt` to install it
+
+  ````shell
+  sudo apt-get install -y python3-opencv
+  ````
+
 </details>
 
 <details>

--- a/docs/train_custom_data.md
+++ b/docs/train_custom_data.md
@@ -7,11 +7,11 @@ We take an example of fine-tuning YOLOX-S model on VOC dataset to give a more cl
 Clone this repo and follow the [README](../README.md) to install YOLOX.
 
 ## 1. Create your own dataset
-**Step 1** Prepare your own dataset with images and labels first. For labeling images, you may use a tool like [Labelme](https://github.com/wkentaro/labelme) or [CVAT](https://github.com/openvinotoolkit/cvat).
+**Step 1** Prepare your own dataset with images and labels first. For labeling images, you can use tools like [Labelme](https://github.com/wkentaro/labelme) or [CVAT](https://github.com/openvinotoolkit/cvat).
 
-**Step 2** Then, you should write the corresponding Dataset Class which can load images and labels through "\_\_getitem\_\_" method. We currently support COCO format and VOC format.
+**Step 2** Then, you should write the corresponding Dataset Class which can load images and labels through `__getitem__` method. We currently support COCO format and VOC format.
 
-You can also write the Dataset by you own. Let's take the [VOC](../yolox/data/datasets/voc.py#L151) Dataset file for example:
+You can also write the Dataset by your own. Let's take the [VOC](../yolox/data/datasets/voc.py#L151) Dataset file for example:
 ```python
     @Dataset.resize_getitem
     def __getitem__(self, index):
@@ -23,27 +23,28 @@ You can also write the Dataset by you own. Let's take the [VOC](../yolox/data/da
         return img, target, img_info, img_id
 ```
 
-One more thing worth noting is that you should also implement "[pull_item](../yolox/data/datasets/voc.py#L129)" and "[load_anno](../yolox/data/datasets/voc.py#L121)" method for the Mosiac and MixUp augmentation.
+One more thing worth noting is that you should also implement [pull_item](../yolox/data/datasets/voc.py#L129) and [load_anno](../yolox/data/datasets/voc.py#L121) method for the `Mosiac` and `MixUp` augmentations.
 
 **Step 3** Prepare the evaluator. We currently have [COCO evaluator](../yolox/evaluators/coco_evaluator.py) and [VOC evaluator](../yolox/evaluators/voc_evaluator.py).
-If you have your own format data or evaluation metric, you may write your own evaluator.
+If you have your own format data or evaluation metric, you can write your own evaluator.
 
-**Step 4** Put your dataset under $YOLOX_DIR/datasets$, for VOC:
+**Step 4** Put your dataset under `$YOLOX_DIR/datasets`, for VOC:
+
 ```shell
 ln -s /path/to/your/VOCdevkit ./datasets/VOCdevkit
 ```
-* The path "VOCdevkit" will be used in your exp file described in next section.Specifically, in "get_data_loader" and "get_eval_loader" function.
+* The path "VOCdevkit" will be used in your exp file described in next section. Specifically, in `get_data_loader` and `get_eval_loader` function.
 
 ## 2. Create your Exp file to control everything
 We put everything involved in a model to one single Exp file, including model setting, training setting, and testing setting.
 
 **A complete Exp file is at [yolox_base.py](../yolox/exp/yolox_base.py).** It may be too long to write for every exp, but you can inherit the base Exp file and only overwrite the changed part.
 
-Let's still take the [VOC Exp file](../exps/example/yolox_voc/yolox_voc_s.py) for an example.
+Let's take the [VOC Exp file](../exps/example/yolox_voc/yolox_voc_s.py) as an example.
 
-We select YOLOX-S model here, so we should change the network depth and width. VOC has only 20 classes, so we should also change the num_classes.
+We select `YOLOX-S` model here, so we should change the network depth and width. VOC has only 20 classes, so we should also change the `num_classes`.
 
-These configs are changed in the init() methd:
+These configs are changed in the `init()` method:
 ```python
 class Exp(MyExp):
     def __init__(self):
@@ -54,19 +55,19 @@ class Exp(MyExp):
         self.exp_name = os.path.split(os.path.realpath(__file__))[1].split(".")[0]
 ```
 
-Besides, you should also overwrite the dataset and evaluator preprared before to training the model on your own data.
+Besides, you should also overwrite the `dataset` and `evaluator`, prepared before training the model on your own data.
 
-Please see "[get_data_loader](../exps/example/yolox_voc/yolox_voc_s.py#L20)", "[get_eval_loader](../exps/example/yolox_voc/yolox_voc_s.py#L82)", and "[get_evaluator](../exps/example/yolox_voc/yolox_voc_s.py#L113)" for more details.
+Please see [get_data_loader](../exps/example/yolox_voc/yolox_voc_s.py#L20), [get_eval_loader](../exps/example/yolox_voc/yolox_voc_s.py#L82), and [get_evaluator](../exps/example/yolox_voc/yolox_voc_s.py#L113) for more details.
 
 ## 3. Train
-Except special cases, we always recommend to use our [COCO pretrained weights](../README.md) for initializing.
+Except special cases, we always recommend to use our [COCO pretrained weights](../README.md) for initializing the model.
 
-Once you get the Exp file and the COCO pretrained weights we provided, you can train your own model by the following command:
+Once you get the Exp file and the COCO pretrained weights we provided, you can train your own model by the following below command:
 ```bash
 python tools/train.py -f /path/to/your/Exp/file -d 8 -b 64 --fp16 -o -c /path/to/the/pretrained/weights
 ```
 
-or take the YOLOX-S VOC training for example:
+or take the `YOLOX-S` VOC training for example:
 ```bash
 python tools/train.py -f exps/example/yolox_voc/yolox_voc_s.py -d 8 -b 64 --fp16 -o -c /path/to/yolox_s.pth.tar
 ```
@@ -75,16 +76,17 @@ python tools/train.py -f exps/example/yolox_voc/yolox_voc_s.py -d 8 -b 64 --fp16
 
 ## 4. Tips for Best Training Results
 
-As YOLOX is an anchor-free detector with only several hyper-parameters, most of the time good results can be obtained with no changes to the models or training settings.
+As **YOLOX** is an anchor-free detector with only several hyper-parameters, most of the time good results can be obtained with no changes to the models or training settings.
 We thus always recommend you first train with all default training settings.
 
-If at first you don't get good results, there are steps you could consider to take to improve.
+If at first you don't get good results, there are steps you could consider to improve the model.
 
-**Model Selection** We provide YOLOX-Nano, YOLOX-Tiny, and YOLOX-S for mobile deployments, while YOLOX-M/L/X for cloud or high performance GPU deployments.
+**Model Selection** We provide `YOLOX-Nano`, `YOLOX-Tiny`, and `YOLOX-S` for mobile deployments, while `YOLOX-M`/`L`/`X` for cloud or high performance GPU deployments.
 
-If your deployment meets some trouble of compatibility. we recommand YOLOX-DarkNet53.
+If your deployment meets any compatibility issues. we recommend `YOLOX-DarkNet53`.
 
 **Training Configs** If your training overfits early, then you can reduce max\_epochs or decrease the base\_lr and min\_lr\_ratio in your Exp file:
+
 ```python
 # --------------  training config --------------------- #
     self.warmup_epochs = 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # TODO: Update with exact module version
 numpy
-torch
+torch>=1.7
+opencv_python
 loguru
 scikit-image
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # TODO: Update with exact module version
 numpy
 torch
-opencv_python
 loguru
 scikit-image
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ tensorboard
 
 # verified versions
 onnx==1.8.1
-onnx-simplifier==0.3.5
 onnxruntime-gpu==1.8.0
+onnx-simplifier==0.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ tensorboard
 
 # verified versions
 onnx==1.8.1
-onnxruntime-gpu==1.8.0
+onnxruntime==1.8.0
 onnx-simplifier==0.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# TODO: Update with exact module version
 numpy
 torch
 opencv_python
@@ -10,4 +11,8 @@ thop
 ninja
 tabulate
 tensorboard
-onnxruntime
+
+# verified versions
+onnx==1.8.1
+onnx-simplifier==0.3.5
+onnxruntime-gpu==1.8.0

--- a/tools/export_onnx.py
+++ b/tools/export_onnx.py
@@ -8,8 +8,6 @@ from loguru import logger
 
 import torch
 from torch import nn
-import onnx
-from onnxsim import simplify
 
 from yolox.exp import get_exp
 from yolox.models.network_blocks import SiLU
@@ -18,30 +16,25 @@ from yolox.utils import replace_module
 
 def make_parser():
     parser = argparse.ArgumentParser("YOLOX onnx deploy")
-    parser.add_argument(
-        "--output-name", type=str, default="yolox.onnx", help="output name of models"
-    )
-    parser.add_argument("--input", default="images", type=str, help="input node name of onnx model")
-    parser.add_argument("--output", default="output", type=str, help="output node name of onnx model")
-    parser.add_argument("-o", "--opset", default=11, type=int, help="onnx opset version")
-    parser.add_argument("--no-onnxsim", action="store_true", help="use onnxsim or not")
-
-    parser.add_argument(
-        "-f",
-        "--exp_file",
-        default=None,
-        type=str,
-        help="expriment description file",
-    )
+    parser.add_argument("--output-name", type=str, default="yolox.onnx",
+                        help="output name of models")
+    parser.add_argument("--input", default="images", type=str,
+                        help="input node name of onnx model")
+    parser.add_argument("--output", default="output", type=str,
+                        help="output node name of onnx model")
+    parser.add_argument("-o", "--opset", default=11, type=int,
+                        help="onnx opset version")
+    parser.add_argument("--no-onnxsim", action="store_true",
+                        help="use onnxsim or not")
+    parser.add_argument("-f", "--exp_file", default=None, type=str,
+                        help="expriment description file",)
     parser.add_argument("-expn", "--experiment-name", type=str, default=None)
-    parser.add_argument("-n", "--name", type=str, default=None, help="model name")
-    parser.add_argument("-c", "--ckpt", default=None, type=str, help="ckpt path")
-    parser.add_argument(
-        "opts",
-        help="Modify config options using the command-line",
-        default=None,
-        nargs=argparse.REMAINDER,
-    )
+    parser.add_argument("-n", "--name", type=str, default=None,
+                        help="model name")
+    parser.add_argument("-c", "--ckpt", default=None, type=str,
+                        help="ckpt path")
+    parser.add_argument("opts", help="Modify config options using the command-line",
+                        default=None, nargs=argparse.REMAINDER,)
 
     return parser
 
@@ -86,8 +79,11 @@ def main():
     logger.info("generated onnx model named {}".format(args.output_name))
 
     if not args.no_onnxsim:
+        import onnx
+        from onnxsim import simplify
+
         # use onnxsimplify to reduce reduent model.
-        onnx_model = onnx.load(args.output_name)  # load onnx model
+        onnx_model = onnx.load(args.output_name)
         model_simp, check = simplify(onnx_model)
         assert check, "Simplified ONNX model could not be validated"
         onnx.save(model_simp, args.output_name)


### PR DESCRIPTION
- For exporting simplified ONNX model, `os.system()` method is not recommended as it is calling `python3` which is not the default alias for many people.
- `requirements.txt` doesn't points to exact module versions hence can break in future. Request the maintainer to add `==` or `>=` while adding python module versions.
- Fixed Training Docs