### PR TITLE
Mirror probability as an option

### DIFF
--- a/exps/default/yolov3.py
+++ b/exps/default/yolov3.py
@@ -15,6 +15,7 @@ class Exp(MyExp):
         self.depth = 1.0
         self.width = 1.0
         self.exp_name = os.path.split(os.path.realpath(__file__))[1].split(".")[0]
+        self.mirror = 0.5
 
     def get_model(self, sublinear=False):
         def init_yolo(M):
@@ -46,6 +47,7 @@ class Exp(MyExp):
                 preproc=TrainTransform(
                     rgb_means=(0.485, 0.456, 0.406),
                     std=(0.229, 0.224, 0.225),
+                    mirror=self.mirror,
                     max_labels=50
                 ),
         )
@@ -57,6 +59,7 @@ class Exp(MyExp):
             preproc=TrainTransform(
                 rgb_means=(0.485, 0.456, 0.406),
                 std=(0.229, 0.224, 0.225),
+                mirror=self.mirror,
                 max_labels=120
             ),
             degrees=self.degrees,

--- a/exps/example/yolox_voc/yolox_voc_s.py
+++ b/exps/example/yolox_voc/yolox_voc_s.py
@@ -15,6 +15,7 @@ class Exp(MyExp):
         self.depth = 0.33
         self.width = 0.50
         self.exp_name = os.path.split(os.path.realpath(__file__))[1].split(".")[0]
+        self.mirror = 0.5
 
     def get_data_loader(self, batch_size, is_distributed, no_aug=False):
         from yolox.data import (
@@ -33,6 +34,7 @@ class Exp(MyExp):
             preproc=TrainTransform(
                 rgb_means=(0.485, 0.456, 0.406),
                 std=(0.229, 0.224, 0.225),
+                mirror=self.mirror,
                 max_labels=50,
             ),
         )
@@ -44,6 +46,7 @@ class Exp(MyExp):
             preproc=TrainTransform(
                 rgb_means=(0.485, 0.456, 0.406),
                 std=(0.229, 0.224, 0.225),
+                mirror=self.mirror,
                 max_labels=120,
             ),
             degrees=self.degrees,

--- a/yolox/exp/yolox_base.py
+++ b/yolox/exp/yolox_base.py
@@ -30,6 +30,7 @@ class Exp(BaseExp):
         self.val_ann = "instances_val2017.json"
 
         # --------------- transform config ----------------- #
+        self.mirror = 0.5
         self.degrees = 10.0
         self.translate = 0.1
         self.scale = (0.1, 2)
@@ -95,6 +96,7 @@ class Exp(BaseExp):
             preproc=TrainTransform(
                 rgb_means=(0.485, 0.456, 0.406),
                 std=(0.229, 0.224, 0.225),
+                mirror=self.mirror,
                 max_labels=50,
             ),
         )
@@ -106,6 +108,7 @@ class Exp(BaseExp):
             preproc=TrainTransform(
                 rgb_means=(0.485, 0.456, 0.406),
                 std=(0.229, 0.224, 0.225),
+                mirror=self.mirror,
                 max_labels=120,
             ),
             degrees=self.degrees,


### PR DESCRIPTION
I think we should add mirror probability as an option for data augmentation.
Currently, I see YOLOX enables flipping by default, and there is no way to disable this augmentation from the configuration file.
However, in many use cases, for example, traffic sign detection, we need to disable this augmentation (set mirror probability = 0) to have correct results. If we flip "turn left" sign, it becomes "turn right". There are also traffic signs and objects that should not be flipped.

![turn_left](https://user-images.githubusercontent.com/18329471/127444758-fb658003-f354-45b5-a641-814d72b55d36.png)
