### PR TITLE
Fix compile error in Windows environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ with open("yolox/__init__.py", "r") as f:
     ).group(1)
 
 
-with open("README.md", "r") as f:
+with open("README.md", "r", encoding="utf-8") as f:
     long_description = f.read()
 
 


### PR DESCRIPTION
Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "D:\deep\yolox-cake\setup.py", line 51, in <module>
        long_description = f.read()
    UnicodeDecodeError: 'gbk' codec can't decode byte 0x90 in position 425: illegal multibyte sequence