### PR TITLE
Skip to save unused tensor in dynamic_k_matching function

### DIFF
--- a/yolox/models/yolo_head.py
+++ b/yolox/models/yolo_head.py
@@ -628,7 +628,7 @@ class YOLOXHead(nn.Module):
 
         anchor_matching_gt = matching_matrix.sum(0)
         if (anchor_matching_gt > 1).sum() > 0:
-            cost_min, cost_argmin = torch.min(cost[:, anchor_matching_gt > 1], dim=0)
+            _, cost_argmin = torch.min(cost[:, anchor_matching_gt > 1], dim=0)
             matching_matrix[:, anchor_matching_gt > 1] *= 0.0
             matching_matrix[cost_argmin, anchor_matching_gt > 1] = 1.0
         fg_mask_inboxes = matching_matrix.sum(0) > 0.0


### PR DESCRIPTION
Skip to save unused tensor in dynamic_k_matching function for saving memory usage

Actually, I didn't profile the memory usage of this function after modifying code.