### PR TITLE
use the skiped optimizer after amp.initialize()

### DIFF
--- a/yolox/core/trainer.py
+++ b/yolox/core/trainer.py
@@ -137,7 +137,7 @@ class Trainer:
         self.optimizer = self.exp.get_optimizer(self.args.batch_size)
 
         if self.amp_training:
-            model, optimizer = amp.initialize(model, self.optimizer, opt_level="O1")
+            model, self.optimizer = amp.initialize(model, self.optimizer, opt_level="O1")
 
         # value of epoch will be set in `resume_train`
         model = self.resume_train(model)


### PR DESCRIPTION
After amp.initialize() we get new _model_ and _optimize_ , I noticed that _model_ is used later, but _optimize_ has not been referenced until the end of the function.