### PR TITLE
pr: metric.py

### DIFF
--- a/yolox/utils/metric.py
+++ b/yolox/utils/metric.py
@@ -59,20 +59,28 @@ class AverageMeter:
         self._count = 0
 
     def update(self, value):
-        self._deque.append(value)
+        #for np.array(list(self._deque)) in self.median, self.avg, np.array(list(torch.Tensor)) will raise exception
+        self._deque.append(float(value))
         self._count += 1
         self._total += value
 
     @property
     def median(self):
-        d = np.array(list(self._deque))
-        return np.median(d)
+        # if deque is empty, None will be returned. thus all methods will return None
+        if len(self._deque) ==0:
+            return None
+        else:
+            d = np.array(list(self._deque))
+            return np.median(d)
 
     @property
     def avg(self):
-        # if deque is empty, nan will be returned.
-        d = np.array(list(self._deque))
-        return d.mean()
+        # if deque is empty, None will be returned. thus all methods will return None         
+        if len(self._deque) ==0:
+            return None
+        else:
+            d = np.array(list(self._deque))
+            return d.mean()
 
     @property
     def global_avg(self):
@@ -80,6 +88,7 @@ class AverageMeter:
 
     @property
     def latest(self):
+        # if deque is empty, None will be returned. thus all methods will return None
         return self._deque[-1] if len(self._deque) > 0 else None
 
     @property
@@ -116,6 +125,7 @@ class MeterBuffer(defaultdict):
         for k, v in values.items():
             if isinstance(v, torch.Tensor):
                 v = v.detach()
+                v = float(v) #for np.array(list(self._deque)) in self.median, self.avg, np.array(list(torch.Tensor)) will raise exception
             self[k].update(v)
 
     def clear_meters(self):


### PR DESCRIPTION
(1) unified returned value to 'None' if deque is empty
(2) by float(torch.tensor), fixed bug: for np.array(list(self._deque)) in self.median, self.avg, np.array(list(torch.Tensor)) will raise exception
(3) added comments accordingly