### PR TITLE
skip copying bboxes in horizontal flip augmentation for speedup

### DIFF
--- a/yolox/data/data_augment.py
+++ b/yolox/data/data_augment.py
@@ -144,7 +144,6 @@ def _mirror(image, boxes, prob=0.5):
     _, width, _ = image.shape
     if random.random() < prob:
         image = image[:, ::-1]
-        boxes = boxes.copy()
         boxes[:, 0::2] = width - boxes[:, 2::-2]
     return image, boxes
 


### PR DESCRIPTION
@Joker316701882 

I think that we don't need to copy bboxes process in this function.

Could you review it?