### PR TITLE
Add torch to build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "torch",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "torch",
+    "torch>=1.7",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Since `setup.py` imports `torch`

https://github.com/Megvii-BaseDetection/YOLOX/blob/6819425e78e28926d132863d4be20811729c9d44/setup.py#L8

installing `yolox` requires a separate install of `torch` beforehand (as documented in the [README](https://github.com/Megvii-BaseDetection/YOLOX#quick-start)). However, there is a standard way to include build dependencies for a Python package. From the [PyPA docs](https://packaging.python.org/tutorials/packaging-projects/#creating-pyproject-toml):

> pyproject.toml tells build tools (like pip and build) what is required to build your project.

Adding `pyproject.toml` with a `build-system.requires` section that includes `torch` would eliminate the need to install `torch` with a separate command prior to installing `yolox`. (Importantly, this only installs `torch` during the _build_ stage, it still needs to be installed into the Python environment to use the package). This makes it easier to use a library in other packages.

For example, the following fails:

```
pip install git+https://github.com/Megvii-BaseDetection/YOLOX.git

Collecting git+https://github.com/Megvii-BaseDetection/YOLOX.git
  Cloning https://github.com/Megvii-BaseDetection/YOLOX.git to /tmp/pip-req-build-wruzfplt
  Running command git clone -q https://github.com/Megvii-BaseDetection/YOLOX.git /tmp/pip-req-build-wruzfplt
  Resolved https://github.com/Megvii-BaseDetection/YOLOX.git to commit 6819425e78e28926d132863d4be20811729c9d44
    ERROR: Command errored out with exit status 1:
     command: /home/robert/anaconda3/envs/zamba-package/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-wruzfplt/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-wruzfplt/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-dveu39rs
         cwd: /tmp/pip-req-build-wruzfplt/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-wruzfplt/setup.py", line 8, in <module>
        import torch
    ModuleNotFoundError: No module named 'torch'
    ----------------------------------------
```

Whereas this succeeds:

```
pip install git+https://github.com/r-b-g-b/YOLOX.git@build-requirements

Collecting git+https://github.com/r-b-g-b/YOLOX.git@build-requirements
  Cloning https://github.com/r-b-g-b/YOLOX.git (to revision build-requirements) to /tmp/pip-req-build-z748qonp
  Running command git clone -q https://github.com/r-b-g-b/YOLOX.git /tmp/pip-req-build-z748qonp
  Running command git checkout -b build-requirements --track origin/build-requirements
  Switched to a new branch 'build-requirements'
  Branch 'build-requirements' set up to track remote branch 'build-requirements' from 'origin'.
  Resolved https://github.com/r-b-g-b/YOLOX.git to commit 3631ad70d1b01d5988ff5745655eb2ff182d5bd9
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
```