### PR TITLE
fix yolo_head.py not support fp16 when fallback to cpu mode

### DIFF
--- a/yolox/models/yolo_head.py
+++ b/yolox/models/yolo_head.py
@@ -489,7 +489,7 @@ class YOLOXHead(nn.Module):
         with torch.cuda.amp.autocast(enabled=False):
             cls_preds_ = (
                 cls_preds_.float().unsqueeze(0).repeat(num_gt, 1, 1).sigmoid_()
-                * obj_preds_.unsqueeze(0).repeat(num_gt, 1, 1).sigmoid_()
+                * obj_preds_.float().unsqueeze(0).repeat(num_gt, 1, 1).sigmoid_()
             )
             pair_wise_cls_loss = F.binary_cross_entropy(
                 cls_preds_.sqrt_(), gt_cls_per_image, reduction="none"


### PR DESCRIPTION
avoid `RuntimeError: "sigmoid_cpu" not implemented for 'Half'`
```
  File ".\YOLOX\yolox\models\yolo_head.py", line 203, in forward
    dtype=xin[0].dtype,
          └ <unprintable tuple object>

  File ".\YOLOX\yolox\models\yolo_head.py", line 357, in get_losses
    "cpu",

  File "..\lib\site-packages\torch\autograd\grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
           │     │       └ {}
           │     └ <unprintable tuple object>
           └ <function YOLOXHead.get_assignments at 0x000001E906CFDA68>

  File ".\YOLOX\yolox\models\yolo_head.py", line 492, in get_assignments
    * obj_preds_.unsqueeze(0).repeat(num_gt, 1, 1).sigmoid_()
      │          │                   └ 84
      │          └ <method 'unsqueeze' of 'torch._C._TensorBase' objects>
      └ tensor([[-4.2734],
                [-5.5000],
                [-7.6758],
                ...,
                [-3.6504],
                [-8.5625],
                [-8.9297]...

RuntimeError: "sigmoid_cpu" not implemented for 'Half'
```