### PR TITLE
support setting max batch/workspace size when convert to trt

### DIFF
--- a/tools/trt.py
+++ b/tools/trt.py
@@ -27,6 +27,7 @@ def make_parser():
         help="pls input your expriment description file",
     )
     parser.add_argument("-c", "--ckpt", default=None, type=str, help="ckpt path")
+    parser.add_argument("-b", '--batch', type=int, default=1, help='max batch size in detect')
     return parser
 
 
@@ -60,6 +61,7 @@ def main():
         fp16_mode=True,
         log_level=trt.Logger.INFO,
         max_workspace_size=(1 << 32),
+        max_batch_size=args.batch,
     )
     torch.save(model_trt.state_dict(), os.path.join(file_name, "model_trt.pth"))
     logger.info("Converted TensorRT model done.")

--- a/tools/trt.py
+++ b/tools/trt.py
@@ -27,6 +27,7 @@ def make_parser():
         help="pls input your expriment description file",
     )
     parser.add_argument("-c", "--ckpt", default=None, type=str, help="ckpt path")
+    parser.add_argument("-w", '--workspace', type=int, default=32, help='max workspace size in detect')
     parser.add_argument("-b", '--batch', type=int, default=1, help='max batch size in detect')
     return parser
 
@@ -60,7 +61,7 @@ def main():
         [x],
         fp16_mode=True,
         log_level=trt.Logger.INFO,
-        max_workspace_size=(1 << 32),
+        max_workspace_size=(1 << args.workspace),
         max_batch_size=args.batch,
     )
     torch.save(model_trt.state_dict(), os.path.join(file_name, "model_trt.pth"))


### PR DESCRIPTION
to avoid
```
[TensorRT] ERROR: Parameter check failed at: engine.cpp::enqueue::387, condition: batchSize > 0 && batchSize <= mEngine.getMaxBatchSize(). Note: Batch size was: 64, but engine max batch size was: 1
```
and avoid the program be kill because of OOM