### PR TITLE
Write date in checkpoint

### DIFF
--- a/yolox/core/trainer.py
+++ b/yolox/core/trainer.py
@@ -2,7 +2,7 @@
 # -*- coding:utf-8 -*-
 # Copyright (c) Megvii, Inc. and its affiliates.
 
-import datetime
+from datetime import datetime
 import os
 import time
 from loguru import logger
@@ -320,6 +320,7 @@ class Trainer:
                 "start_epoch": self.epoch + 1,
                 "model": save_model.state_dict(),
                 "optimizer": self.optimizer.state_dict(),
+                "date": datetime.now().isoformat(),
             }
             save_checkpoint(
                 ckpt_state,

--- a/yolox/core/trainer.py
+++ b/yolox/core/trainer.py
@@ -2,9 +2,9 @@
 # -*- coding:utf-8 -*-
 # Copyright (c) Megvii, Inc. and its affiliates.
 
-from datetime import datetime
 import os
 import time
+from datetime import datetime
 from loguru import logger
 
 import torch


### PR DESCRIPTION
Write date in checkpoint

If we write date in checkpoint file, we may more easily manage the version of the weights file.

I also contributed to the yolov5 project with this idea.

https://github.com/ultralytics/yolov5/issues/5513

https://github.com/ultralytics/yolov5/pull/5514
