### PR TITLE
revert "Add torch to build requirements"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,0 @@
-[build-system]
-requires = [
-    "setuptools>=42",
-    "torch>=1.7",
-    "wheel",
-]
-build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Reverts Megvii-BaseDetection/YOLOX#682, pyproject.toml might cause cache problem during  `pip install`.