### PR TITLE
Change os.path to Pathlib to avoid issues with Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,18 +70,11 @@ This repo is an implementation of PyTorch version YOLOX, there is also a [MegEng
 <details>
 <summary>Installation</summary>
 
-Step1. Install YOLOX.
+Step1. Install YOLOX from source.
 ```shell
 git clone git@github.com:Megvii-BaseDetection/YOLOX.git
 cd YOLOX
-pip3 install -U pip && pip3 install -r requirements.txt
 pip3 install -v -e .  # or  python3 setup.py develop
-```
-
-Step2. Install [pycocotools](https://github.com/cocodataset/cocoapi).
-
-```shell
-pip3 install cython; pip3 install 'git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI'
 ```
 
 </details>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+from pathlib import Path
 import sys
 from unittest import mock
 from sphinx.domains import Domain
@@ -64,7 +65,7 @@ class GithubURLDomain(Domain):
 # to support markdown
 from recommonmark.parser import CommonMarkParser
 
-sys.path.insert(0, os.path.abspath("../"))
+sys.path.insert(0, str(Path("../").resolve()))
 os.environ["_DOC_BUILDING"] = "True"
 DEPLOY = os.environ.get("READTHEDOCS") == "True"
 

--- a/docs/train_custom_data.md
+++ b/docs/train_custom_data.md
@@ -55,7 +55,7 @@ class Exp(MyExp):
         self.num_classes = 20
         self.depth = 0.33
         self.width = 0.50
-        self.exp_name = os.path.split(os.path.realpath(__file__))[1].split(".")[0]
+        self.exp_name = Path(__file__).resolve().stem
 ```
 
 Besides, you should also overwrite the `dataset` and `evaluator`, prepared before training the model on your own data.

--- a/exps/default/__init__.py
+++ b/exps/default/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+# Copyright (c) Megvii, Inc. and its affiliates.

--- a/exps/default/yolov3.py
+++ b/exps/default/yolov3.py
@@ -2,7 +2,7 @@
 # -*- coding:utf-8 -*-
 # Copyright (c) Megvii, Inc. and its affiliates.
 
-import os
+from pathlib import Path
 
 import torch.nn as nn
 
@@ -14,7 +14,7 @@ class Exp(MyExp):
         super(Exp, self).__init__()
         self.depth = 1.0
         self.width = 1.0
-        self.exp_name = os.path.split(os.path.realpath(__file__))[1].split(".")[0]
+        self.exp_name = Path(__file__).resolve().stem
 
     def get_model(self, sublinear=False):
         def init_yolo(M):

--- a/exps/default/yolox_l.py
+++ b/exps/default/yolox_l.py
@@ -2,7 +2,7 @@
 # -*- coding:utf-8 -*-
 # Copyright (c) Megvii, Inc. and its affiliates.
 
-import os
+from pathlib import Path
 
 from yolox.exp import Exp as MyExp
 
@@ -12,4 +12,4 @@ class Exp(MyExp):
         super(Exp, self).__init__()
         self.depth = 1.0
         self.width = 1.0
-        self.exp_name = os.path.split(os.path.realpath(__file__))[1].split(".")[0]
+        self.exp_name = Path(__file__).resolve().stem

--- a/exps/default/yolox_m.py
+++ b/exps/default/yolox_m.py
@@ -2,7 +2,7 @@
 # -*- coding:utf-8 -*-
 # Copyright (c) Megvii, Inc. and its affiliates.
 
-import os
+from pathlib import Path
 
 from yolox.exp import Exp as MyExp
 
@@ -12,4 +12,4 @@ class Exp(MyExp):
         super(Exp, self).__init__()
         self.depth = 0.67
         self.width = 0.75
-        self.exp_name = os.path.split(os.path.realpath(__file__))[1].split(".")[0]
+        self.exp_name = Path(__file__).resolve().stem

--- a/exps/default/yolox_nano.py
+++ b/exps/default/yolox_nano.py
@@ -2,7 +2,7 @@
 # -*- coding:utf-8 -*-
 # Copyright (c) Megvii, Inc. and its affiliates.
 
-import os
+from pathlib import Path
 
 import torch.nn as nn
 
@@ -20,7 +20,7 @@ class Exp(MyExp):
         self.test_size = (416, 416)
         self.mosaic_prob = 0.5
         self.enable_mixup = False
-        self.exp_name = os.path.split(os.path.realpath(__file__))[1].split(".")[0]
+        self.exp_name = Path(__file__).resolve().stem
 
     def get_model(self, sublinear=False):
 

--- a/exps/default/yolox_s.py
+++ b/exps/default/yolox_s.py
@@ -2,7 +2,7 @@
 # -*- coding:utf-8 -*-
 # Copyright (c) Megvii, Inc. and its affiliates.
 
-import os
+from pathlib import Path
 
 from yolox.exp import Exp as MyExp
 
@@ -12,4 +12,4 @@ class Exp(MyExp):
         super(Exp, self).__init__()
         self.depth = 0.33
         self.width = 0.50
-        self.exp_name = os.path.split(os.path.realpath(__file__))[1].split(".")[0]
+        self.exp_name = Path(__file__).resolve().stem

--- a/exps/default/yolox_tiny.py
+++ b/exps/default/yolox_tiny.py
@@ -2,7 +2,7 @@
 # -*- coding:utf-8 -*-
 # Copyright (c) Megvii, Inc. and its affiliates.
 
-import os
+from pathlib import Path
 
 from yolox.exp import Exp as MyExp
 
@@ -16,5 +16,5 @@ class Exp(MyExp):
         self.mosaic_scale = (0.5, 1.5)
         self.random_size = (10, 20)
         self.test_size = (416, 416)
-        self.exp_name = os.path.split(os.path.realpath(__file__))[1].split(".")[0]
+        self.exp_name = Path(__file__).resolve().stem
         self.enable_mixup = False

--- a/exps/default/yolox_x.py
+++ b/exps/default/yolox_x.py
@@ -2,7 +2,7 @@
 # -*- coding:utf-8 -*-
 # Copyright (c) Megvii, Inc. and its affiliates.
 
-import os
+from pathlib import Path
 
 from yolox.exp import Exp as MyExp
 
@@ -12,4 +12,4 @@ class Exp(MyExp):
         super(Exp, self).__init__()
         self.depth = 1.33
         self.width = 1.25
-        self.exp_name = os.path.split(os.path.realpath(__file__))[1].split(".")[0]
+        self.exp_name = Path(__file__).resolve().stem

--- a/exps/example/custom/nano.py
+++ b/exps/example/custom/nano.py
@@ -2,7 +2,7 @@
 # -*- coding:utf-8 -*-
 # Copyright (c) Megvii, Inc. and its affiliates.
 
-import os
+from pathlib import Path
 
 import torch.nn as nn
 
@@ -18,7 +18,7 @@ class Exp(MyExp):
         self.mosaic_scale = (0.5, 1.5)
         self.random_size = (10, 20)
         self.test_size = (416, 416)
-        self.exp_name = os.path.split(os.path.realpath(__file__))[1].split(".")[0]
+        self.exp_name = Path(__file__).resolve().stem
         self.enable_mixup = False
 
         # Define yourself dataset path

--- a/exps/example/custom/yolox_s.py
+++ b/exps/example/custom/yolox_s.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 # Copyright (c) Megvii, Inc. and its affiliates.
-import os
+from pathlib import Path
 
 from yolox.exp import Exp as MyExp
 
@@ -11,7 +11,7 @@ class Exp(MyExp):
         super(Exp, self).__init__()
         self.depth = 0.33
         self.width = 0.50
-        self.exp_name = os.path.split(os.path.realpath(__file__))[1].split(".")[0]
+        self.exp_name = Path(__file__).resolve().stem
 
         # Define yourself dataset path
         self.data_dir = "datasets/coco128"

--- a/exps/example/yolox_voc/yolox_voc_s.py
+++ b/exps/example/yolox_voc/yolox_voc_s.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-import os
+from pathlib import Path
 
 import torch
 import torch.distributed as dist
@@ -22,7 +22,7 @@ class Exp(MyExp):
         self.hsv_prob = 1.0
         self.flip_prob = 0.5
 
-        self.exp_name = os.path.split(os.path.realpath(__file__))[1].split(".")[0]
+        self.exp_name = Path(__file__).resolve().stem
 
     def get_data_loader(self, batch_size, is_distributed, no_aug=False, cache_img=False):
         from yolox.data import (
@@ -42,7 +42,7 @@ class Exp(MyExp):
 
         with wait_for_the_master(local_rank):
             dataset = VOCDetection(
-                data_dir=os.path.join(get_yolox_datadir(), "VOCdevkit"),
+                data_dir=get_yolox_datadir() / "VOCdevkit",
                 image_sets=[('2007', 'trainval'), ('2012', 'trainval')],
                 img_size=self.input_size,
                 preproc=TrainTransform(
@@ -100,7 +100,7 @@ class Exp(MyExp):
         from yolox.data import VOCDetection, ValTransform
 
         valdataset = VOCDetection(
-            data_dir=os.path.join(get_yolox_datadir(), "VOCdevkit"),
+            data_dir=get_yolox_datadir() / "VOCdevkit",
             image_sets=[('2007', 'test')],
             img_size=self.test_size,
             preproc=ValTransform(legacy=legacy),

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,8 @@ tabulate
 tensorboard
 
 # verified versions
+# pycocotools corresponds to https://github.com/ppwwyyxx/cocoapi
+pycocotools>=2.0.2
 onnx==1.8.1
 onnxruntime==1.8.0
 onnx-simplifier==0.3.5

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,6 @@ from os import path
 import torch
 from torch.utils.cpp_extension import CppExtension
 
-torch_ver = [int(x) for x in torch.__version__.split(".")[:2]]
-assert torch_ver >= [1, 7], "Requires PyTorch >= 1.7"
-
 
 def get_extensions():
     this_dir = path.dirname(path.abspath(__file__))
@@ -40,25 +37,56 @@ def get_extensions():
     return ext_modules
 
 
-with open("yolox/__init__.py", "r") as f:
-    version = re.search(
-        r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
-        f.read(), re.MULTILINE
-    ).group(1)
+def get_package_dir():
+    pkg_dir = {
+        "yolox.tools": "tools",
+        "yolox.exp.default": "exps/default",
+    }
+    return pkg_dir
 
 
-with open("README.md", "r", encoding="utf-8") as f:
-    long_description = f.read()
+def get_install_requirements():
+    with open("requirements.txt", "r", encoding="utf-8") as f:
+        reqs = [x.strip() for x in f.read().splitlines()]
+    reqs = [x for x in reqs if not x.startswith("#")]
+    return reqs
+
+
+def get_yolox_version():
+    with open("yolox/__init__.py", "r") as f:
+        version = re.search(
+            r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
+            f.read(), re.MULTILINE
+        ).group(1)
+    return version
+
+
+def get_long_description():
+    with open("README.md", "r", encoding="utf-8") as f:
+        long_description = f.read()
+    return long_description
 
 
 setuptools.setup(
     name="yolox",
-    version=version,
-    author="basedet team",
+    version=get_yolox_version(),
+    author="megvii basedet team",
+    url="https://github.com/Megvii-BaseDetection/YOLOX",
+    package_dir=get_package_dir(),
     python_requires=">=3.6",
-    long_description=long_description,
+    install_requires=get_install_requirements(),
+    long_description=get_long_description(),
+    long_description_content_type="text/markdown",
     ext_modules=get_extensions(),
-    classifiers=["Programming Language :: Python :: 3", "Operating System :: OS Independent"],
+    classifiers=[
+        "Programming Language :: Python :: 3", "Operating System :: OS Independent",
+        "License :: OSI Approved :: Apache Software License",
+    ],
     cmdclass={"build_ext": torch.utils.cpp_extension.BuildExtension},
     packages=setuptools.find_packages(),
+    project_urls={
+        "Documentation": "https://yolox.readthedocs.io",
+        "Source": "https://github.com/Megvii-BaseDetection/YOLOX",
+        "Tracker": "https://github.com/Megvii-BaseDetection/YOLOX/issues",
+    },
 )

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+# Copyright (c) Megvii, Inc. and its affiliates.

--- a/tools/demo.py
+++ b/tools/demo.py
@@ -3,7 +3,7 @@
 # Copyright (c) Megvii, Inc. and its affiliates.
 
 import argparse
-import os
+from pathlib import Path
 import time
 from loguru import logger
 
@@ -28,7 +28,7 @@ def make_parser():
     parser.add_argument("-n", "--name", type=str, default=None, help="model name")
 
     parser.add_argument(
-        "--path", default="./assets/dog.jpg", help="path to images or video"
+        "--path", type=Path, default="./assets/dog.jpg", help="path to images or video"
     )
     parser.add_argument("--camid", type=int, default=0, help="webcam demo camera id")
     parser.add_argument(
@@ -42,10 +42,10 @@ def make_parser():
         "-f",
         "--exp_file",
         default=None,
-        type=str,
+        type=Path,
         help="pls input your experiment description file",
     )
-    parser.add_argument("-c", "--ckpt", default=None, type=str, help="ckpt for eval")
+    parser.add_argument("-c", "--ckpt", default=None, type=Path, help="ckpt for eval")
     parser.add_argument(
         "--device",
         default="cpu",
@@ -88,12 +88,11 @@ def make_parser():
 
 def get_image_list(path):
     image_names = []
-    for maindir, subdir, file_name_list in os.walk(path):
-        for filename in file_name_list:
-            apath = os.path.join(maindir, filename)
-            ext = os.path.splitext(apath)[1]
-            if ext in IMAGE_EXT:
-                image_names.append(apath)
+    for file in path.rglob("*.*"):
+        ext = file.suffix
+        if ext in IMAGE_EXT:
+            print(f"file={file}, ext={ext}.")
+            image_names.append(file)
     return image_names
 
 
@@ -131,9 +130,9 @@ class Predictor(object):
 
     def inference(self, img):
         img_info = {"id": 0}
-        if isinstance(img, str):
-            img_info["file_name"] = os.path.basename(img)
-            img = cv2.imread(img)
+        if isinstance(img, Path):
+            img_info["file_name"] = img.name
+            img = cv2.imread(str(img))
         else:
             img_info["file_name"] = None
 
@@ -184,8 +183,8 @@ class Predictor(object):
         return vis_res
 
 
-def image_demo(predictor, vis_folder, path, current_time, save_result):
-    if os.path.isdir(path):
+def image_demo(predictor, vis_folder: Path, path, current_time, save_result):
+    if path.is_dir():
         files = get_image_list(path)
     else:
         files = [path]
@@ -194,34 +193,30 @@ def image_demo(predictor, vis_folder, path, current_time, save_result):
         outputs, img_info = predictor.inference(image_name)
         result_image = predictor.visual(outputs[0], img_info, predictor.confthre)
         if save_result:
-            save_folder = os.path.join(
-                vis_folder, time.strftime("%Y_%m_%d_%H_%M_%S", current_time)
-            )
-            os.makedirs(save_folder, exist_ok=True)
-            save_file_name = os.path.join(save_folder, os.path.basename(image_name))
+            save_folder = vis_folder / time.strftime("%Y_%m_%d_%H_%M_%S", current_time)
+            save_folder.mkdir(parents=True, exist_ok=True)
+            save_file_name = save_folder / image_name.name
             logger.info("Saving detection result in {}".format(save_file_name))
-            cv2.imwrite(save_file_name, result_image)
+            cv2.imwrite(str(save_file_name), result_image)
         ch = cv2.waitKey(0)
         if ch == 27 or ch == ord("q") or ch == ord("Q"):
             break
 
 
 def imageflow_demo(predictor, vis_folder, current_time, args):
-    cap = cv2.VideoCapture(args.path if args.demo == "video" else args.camid)
+    cap = cv2.VideoCapture(str(args.path) if args.demo == "video" else args.camid)
     width = cap.get(cv2.CAP_PROP_FRAME_WIDTH)  # float
     height = cap.get(cv2.CAP_PROP_FRAME_HEIGHT)  # float
     fps = cap.get(cv2.CAP_PROP_FPS)
-    save_folder = os.path.join(
-        vis_folder, time.strftime("%Y_%m_%d_%H_%M_%S", current_time)
-    )
-    os.makedirs(save_folder, exist_ok=True)
+    save_folder = vis_folder / time.strftime("%Y_%m_%d_%H_%M_%S", current_time)
+    save_folder.mkdir(parents=True, exist_ok=True)
     if args.demo == "video":
-        save_path = os.path.join(save_folder, args.path.split("/")[-1])
+        save_path = save_folder / args.path.name
     else:
-        save_path = os.path.join(save_folder, "camera.mp4")
+        save_path = save_folder / "camera.mp4"
     logger.info(f"video save_path is {save_path}")
     vid_writer = cv2.VideoWriter(
-        save_path, cv2.VideoWriter_fourcc(*"mp4v"), fps, (int(width), int(height))
+        str(save_path), cv2.VideoWriter_fourcc(*"mp4v"), fps, (int(width), int(height))
     )
     while True:
         ret_val, frame = cap.read()
@@ -241,13 +236,13 @@ def main(exp, args):
     if not args.experiment_name:
         args.experiment_name = exp.exp_name
 
-    file_name = os.path.join(exp.output_dir, args.experiment_name)
-    os.makedirs(file_name, exist_ok=True)
+    file_name = exp.output_dir / args.experiment_name
+    file_name.mkdir(parents=True, exist_ok=True)
 
     vis_folder = None
     if args.save_result:
-        vis_folder = os.path.join(file_name, "vis_res")
-        os.makedirs(vis_folder, exist_ok=True)
+        vis_folder = file_name / "vis_res"
+        vis_folder.mkdir(parents=True, exist_ok=True)
 
     if args.trt:
         args.device = "gpu"
@@ -272,9 +267,9 @@ def main(exp, args):
 
     if not args.trt:
         if args.ckpt is None:
-            ckpt_file = os.path.join(file_name, "best_ckpt.pth")
+            ckpt_file = file_name / "best_ckpt.pth"
         else:
-            ckpt_file = args.ckpt
+            ckpt_file = Path(args.ckpt)
         logger.info("loading checkpoint")
         ckpt = torch.load(ckpt_file, map_location="cpu")
         # load the model state dict
@@ -287,10 +282,8 @@ def main(exp, args):
 
     if args.trt:
         assert not args.fuse, "TensorRT model is not support model fusing!"
-        trt_file = os.path.join(file_name, "model_trt.pth")
-        assert os.path.exists(
-            trt_file
-        ), "TensorRT model is not found!\n Run python3 tools/trt.py first!"
+        trt_file = file_name / "model_trt.pth"
+        assert trt_file.is_file(), "TensorRT model is not found!\n Run python3 tools/trt.py first!"
         model.head.decode_in_inference = False
         decoder = model.head.decode_outputs
         logger.info("Using TensorRT to inference")

--- a/tools/export_onnx.py
+++ b/tools/export_onnx.py
@@ -3,7 +3,7 @@
 # Copyright (c) Megvii, Inc. and its affiliates.
 
 import argparse
-import os
+from pathlib import Path
 from loguru import logger
 
 import torch
@@ -37,12 +37,12 @@ def make_parser():
         "-f",
         "--exp_file",
         default=None,
-        type=str,
+        type=Path,
         help="expriment description file",
     )
     parser.add_argument("-expn", "--experiment-name", type=str, default=None)
     parser.add_argument("-n", "--name", type=str, default=None, help="model name")
-    parser.add_argument("-c", "--ckpt", default=None, type=str, help="ckpt path")
+    parser.add_argument("-c", "--ckpt", default=None, type=Path, help="ckpt path")
     parser.add_argument(
         "opts",
         help="Modify config options using the command-line",
@@ -65,8 +65,8 @@ def main():
 
     model = exp.get_model()
     if args.ckpt is None:
-        file_name = os.path.join(exp.output_dir, args.experiment_name)
-        ckpt_file = os.path.join(file_name, "best_ckpt.pth")
+        file_name = exp.output_dir / args.experiment_name
+        ckpt_file = file_name / "best_ckpt.pth"
     else:
         ckpt_file = args.ckpt
 

--- a/tools/export_torchscript.py
+++ b/tools/export_torchscript.py
@@ -3,7 +3,7 @@
 # Copyright (c) Megvii, Inc. and its affiliates.
 
 import argparse
-import os
+from pathlib import Path
 from loguru import logger
 
 import torch
@@ -21,12 +21,12 @@ def make_parser():
         "-f",
         "--exp_file",
         default=None,
-        type=str,
+        type=Path,
         help="expriment description file",
     )
     parser.add_argument("-expn", "--experiment-name", type=str, default=None)
     parser.add_argument("-n", "--name", type=str, default=None, help="model name")
-    parser.add_argument("-c", "--ckpt", default=None, type=str, help="ckpt path")
+    parser.add_argument("-c", "--ckpt", default=None, type=Path, help="ckpt path")
     parser.add_argument(
         "opts",
         help="Modify config options using the command-line",
@@ -49,8 +49,8 @@ def main():
 
     model = exp.get_model()
     if args.ckpt is None:
-        file_name = os.path.join(exp.output_dir, args.experiment_name)
-        ckpt_file = os.path.join(file_name, "best_ckpt.pth")
+        file_name = exp.output_dir / args.experiment_name
+        ckpt_file = file_name / "best_ckpt.pth"
     else:
         ckpt_file = args.ckpt
 

--- a/tools/train.py
+++ b/tools/train.py
@@ -5,6 +5,7 @@
 import argparse
 import random
 import warnings
+from pathlib import Path
 from loguru import logger
 
 import torch
@@ -38,13 +39,13 @@ def make_parser():
         "-f",
         "--exp_file",
         default=None,
-        type=str,
+        type=Path,
         help="plz input your experiment description file",
     )
     parser.add_argument(
         "--resume", default=False, action="store_true", help="resume training"
     )
-    parser.add_argument("-c", "--ckpt", default=None, type=str, help="checkpoint file")
+    parser.add_argument("-c", "--ckpt", default=None, type=Path, help="checkpoint file")
     parser.add_argument(
         "-e",
         "--start_epoch",

--- a/tools/trt.py
+++ b/tools/trt.py
@@ -66,7 +66,7 @@ def main():
         max_workspace_size=(1 << args.workspace),
         max_batch_size=args.batch,
     )
-    torch.save(model_trt.state_dict(), file_name /"model_trt.pth")
+    torch.save(model_trt.state_dict(), file_name / "model_trt.pth")
     logger.info("Converted TensorRT model done.")
     engine_file = file_name / "model_trt.engine"
     engine_file_demo = Path("demo") / "TensorRT" / "cpp" / "model_trt.engine"

--- a/yolox/__init__.py
+++ b/yolox/__init__.py
@@ -5,4 +5,4 @@ from .utils import configure_module
 
 configure_module()
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/yolox/core/trainer.py
+++ b/yolox/core/trainer.py
@@ -4,6 +4,7 @@
 
 import datetime
 import os
+from pathlib import Path
 import time
 from loguru import logger
 
@@ -54,10 +55,10 @@ class Trainer:
 
         # metric record
         self.meter = MeterBuffer(window_size=exp.print_interval)
-        self.file_name = os.path.join(exp.output_dir, args.experiment_name)
+        self.file_name = exp.output_dir / args.experiment_name
 
         if self.rank == 0:
-            os.makedirs(self.file_name, exist_ok=True)
+            self.file_name.mkdir(parents=True, exist_ok=True)
 
         setup_logger(
             self.file_name,
@@ -261,7 +262,7 @@ class Trainer:
         if self.args.resume:
             logger.info("resume training")
             if self.args.ckpt is None:
-                ckpt_file = os.path.join(self.file_name, "latest" + "_ckpt.pth")
+                ckpt_file = self.file_name / "latest_ckpt.pth"
             else:
                 ckpt_file = self.args.ckpt
 

--- a/yolox/core/trainer.py
+++ b/yolox/core/trainer.py
@@ -3,8 +3,6 @@
 # Copyright (c) Megvii, Inc. and its affiliates.
 
 import datetime
-import os
-from pathlib import Path
 import time
 from loguru import logger
 

--- a/yolox/data/dataloading.py
+++ b/yolox/data/dataloading.py
@@ -3,9 +3,9 @@
 # Copyright (c) Megvii, Inc. and its affiliates.
 
 import os
-from pathlib import Path
 import random
 import uuid
+from pathlib import Path
 
 import numpy as np
 

--- a/yolox/data/dataloading.py
+++ b/yolox/data/dataloading.py
@@ -3,6 +3,7 @@
 # Copyright (c) Megvii, Inc. and its affiliates.
 
 import os
+from pathlib import Path
 import random
 import uuid
 
@@ -24,8 +25,10 @@ def get_yolox_datadir():
     if yolox_datadir is None:
         import yolox
 
-        yolox_path = os.path.dirname(os.path.dirname(yolox.__file__))
-        yolox_datadir = os.path.join(yolox_path, "datasets")
+        yolox_path = Path(yolox.__file__).resolve().parents[1]
+        yolox_datadir = yolox_path / "datasets"
+    else:
+        yolox_datadir = Path(yolox_datadir)
     return yolox_datadir
 
 

--- a/yolox/data/datasets/coco.py
+++ b/yolox/data/datasets/coco.py
@@ -48,7 +48,7 @@ class COCODataset(Dataset):
         """
         COCO dataset initialization. Annotation data are read into memory by COCO API.
         Args:
-            data_dir (str): dataset root directory
+            data_dir (Path): dataset root directory
             json_file (str): COCO json file name
             name (str): COCO data name (e.g. 'train2017' or 'val2017')
             img_size (int): target image size after pre-processing
@@ -56,11 +56,11 @@ class COCODataset(Dataset):
         """
         super().__init__(img_size)
         if data_dir is None:
-            data_dir = os.path.join(get_yolox_datadir(), "COCO")
+            data_dir = get_yolox_datadir() / "COCO"
         self.data_dir = data_dir
         self.json_file = json_file
 
-        self.coco = COCO(os.path.join(self.data_dir, "annotations", self.json_file))
+        self.coco = COCO(str(self.data_dir / "annotations" / self.json_file))
         remove_useless_info(self.coco)
         self.ids = self.coco.getImgIds()
         self.class_ids = sorted(self.coco.getCatIds())
@@ -93,13 +93,13 @@ class COCODataset(Dataset):
         )
         max_h = self.img_size[0]
         max_w = self.img_size[1]
-        cache_file = self.data_dir + "/img_resized_cache_" + self.name + ".array"
-        if not os.path.exists(cache_file):
+        cache_file = self.data_dir / f"img_resized_cache_{self.name}.array"
+        if not cache_file.is_file():
             logger.info(
                 "Caching images for the first time. This might take about 20 minutes for COCO"
             )
             self.imgs = np.memmap(
-                cache_file,
+                str(cache_file),
                 shape=(len(self.ids), max_h, max_w, 3),
                 dtype=np.uint8,
                 mode="w+",
@@ -126,7 +126,7 @@ class COCODataset(Dataset):
 
         logger.info("Loading cached imgs...")
         self.imgs = np.memmap(
-            cache_file,
+            str(cache_file),
             shape=(len(self.ids), max_h, max_w, 3),
             dtype=np.uint8,
             mode="r+",
@@ -187,9 +187,9 @@ class COCODataset(Dataset):
     def load_image(self, index):
         file_name = self.annotations[index][3]
 
-        img_file = os.path.join(self.data_dir, self.name, file_name)
+        img_file = self.data_dir / self.name / file_name
 
-        img = cv2.imread(img_file)
+        img = cv2.imread(str(img_file))
         assert img is not None
 
         return img

--- a/yolox/data/datasets/voc.py
+++ b/yolox/data/datasets/voc.py
@@ -8,9 +8,9 @@
 
 import os
 import os.path
-from pathlib import Path
 import pickle
 import xml.etree.ElementTree as ET
+from pathlib import Path
 from loguru import logger
 
 import cv2

--- a/yolox/evaluators/voc_eval.py
+++ b/yolox/evaluators/voc_eval.py
@@ -5,7 +5,6 @@
 # Copyright (c) Bharath Hariharan.
 # Copyright (c) Megvii, Inc. and its affiliates.
 
-import os
 import pickle
 import xml.etree.ElementTree as ET
 

--- a/yolox/evaluators/voc_eval.py
+++ b/yolox/evaluators/voc_eval.py
@@ -78,28 +78,27 @@ def voc_eval(
     use_07_metric=False,
 ):
     # first load gt
-    if not os.path.isdir(cachedir):
-        os.mkdir(cachedir)
-    cachefile = os.path.join(cachedir, "annots.pkl")
+    cachedir.mkdir(parents=True, exist_ok=True)
+    cachefile = cachedir / "annots.pkl"
     # read list of images
-    with open(imagesetfile, "r") as f:
+    with imagesetfile.open("r") as f:
         lines = f.readlines()
     imagenames = [x.strip() for x in lines]
 
-    if not os.path.isfile(cachefile):
+    if not cachefile.is_file():
         # load annots
         recs = {}
         for i, imagename in enumerate(imagenames):
-            recs[imagename] = parse_rec(annopath.format(imagename))
+            recs[imagename] = parse_rec(str(annopath).format(imagename))
             if i % 100 == 0:
                 print("Reading annotation for {:d}/{:d}".format(i + 1, len(imagenames)))
         # save
         print("Saving cached annotations to {:s}".format(cachefile))
-        with open(cachefile, "wb") as f:
+        with cachefile.open("wb") as f:
             pickle.dump(recs, f)
     else:
         # load
-        with open(cachefile, "rb") as f:
+        with cachefile.open("rb") as f:
             recs = pickle.load(f)
 
     # extract gt objects for this class
@@ -114,7 +113,7 @@ def voc_eval(
         class_recs[imagename] = {"bbox": bbox, "difficult": difficult, "det": det}
 
     # read dets
-    detfile = detpath.format(classname)
+    detfile = str(detpath).format(classname)
     with open(detfile, "r") as f:
         lines = f.readlines()
 

--- a/yolox/evaluators/voc_evaluator.py
+++ b/yolox/evaluators/voc_evaluator.py
@@ -2,6 +2,7 @@
 # -*- coding:utf-8 -*-
 # Copyright (c) Megvii, Inc. and its affiliates.
 
+from pathlib import Path
 import sys
 import tempfile
 import time
@@ -203,6 +204,6 @@ class VOCEvaluator:
 
         with tempfile.TemporaryDirectory() as tempdir:
             mAP50, mAP70 = self.dataloader.dataset.evaluate_detections(
-                all_boxes, tempdir
+                all_boxes, Path(tempdir)
             )
             return mAP50, mAP70, info

--- a/yolox/evaluators/voc_evaluator.py
+++ b/yolox/evaluators/voc_evaluator.py
@@ -2,11 +2,11 @@
 # -*- coding:utf-8 -*-
 # Copyright (c) Megvii, Inc. and its affiliates.
 
-from pathlib import Path
 import sys
 import tempfile
 import time
 from collections import ChainMap
+from pathlib import Path
 from loguru import logger
 from tqdm import tqdm
 

--- a/yolox/exp/base_exp.py
+++ b/yolox/exp/base_exp.py
@@ -7,6 +7,7 @@ import pprint
 from abc import ABCMeta, abstractmethod
 from typing import Dict
 from tabulate import tabulate
+from pathlib import Path
 
 import torch
 from torch.nn import Module
@@ -19,7 +20,7 @@ class BaseExp(metaclass=ABCMeta):
 
     def __init__(self):
         self.seed = None
-        self.output_dir = "./YOLOX_outputs"
+        self.output_dir = Path("./YOLOX_outputs")
         self.print_interval = 100
         self.eval_interval = 10
 

--- a/yolox/exp/base_exp.py
+++ b/yolox/exp/base_exp.py
@@ -5,9 +5,9 @@
 import ast
 import pprint
 from abc import ABCMeta, abstractmethod
+from pathlib import Path
 from typing import Dict
 from tabulate import tabulate
-from pathlib import Path
 
 import torch
 from torch.nn import Module

--- a/yolox/exp/build.py
+++ b/yolox/exp/build.py
@@ -3,21 +3,21 @@
 # Copyright (c) 2014-2021 Megvii Inc. All rights reserved.
 
 import importlib
-import os
 import sys
+from pathlib import Path
 
 
-def get_exp_by_file(exp_file):
+def get_exp_by_file(exp_file: Path):
     try:
-        sys.path.append(os.path.dirname(exp_file))
-        current_exp = importlib.import_module(os.path.basename(exp_file).split(".")[0])
+        sys.path.append(str(exp_file.parent))
+        current_exp = importlib.import_module(str(exp_file.stem))
         exp = current_exp.Exp()
     except Exception:
         raise ImportError("{} doesn't contains class named 'Exp'".format(exp_file))
     return exp
 
 
-def get_exp_by_name(exp_name):
+def get_exp_by_name(exp_name: str):
     exp = exp_name.replace("-", "_")  # convert string like "yolox-s" to "yolox_s"
     module_name = ".".join(["yolox", "exp", "default", exp])
     exp_object = importlib.import_module(module_name).Exp()
@@ -30,7 +30,7 @@ def get_exp(exp_file=None, exp_name=None):
     are both provided, get Exp by exp_file.
 
     Args:
-        exp_file (str): file path of experiment.
+        exp_file (Path): file path of experiment.
         exp_name (str): name of experiment. "yolo-s",
     """
     assert (

--- a/yolox/exp/yolox_base.py
+++ b/yolox/exp/yolox_base.py
@@ -2,8 +2,8 @@
 # -*- coding:utf-8 -*-
 # Copyright (c) 2014-2021 Megvii Inc. All rights reserved.
 
-import os
 import random
+from pathlib import Path
 
 import torch
 import torch.distributed as dist
@@ -63,7 +63,7 @@ class Exp(BaseExp):
         self.momentum = 0.9
         self.print_interval = 10
         self.eval_interval = 10
-        self.exp_name = os.path.split(os.path.realpath(__file__))[1].split(".")[0]
+        self.exp_name = Path(__file__).resolve().stem
 
         # -----------------  testing config ------------------ #
         self.test_size = (640, 640)

--- a/yolox/utils/checkpoint.py
+++ b/yolox/utils/checkpoint.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 # Copyright (c) 2014-2021 Megvii Inc. All rights reserved.
-import os
 import shutil
 from loguru import logger
 
@@ -34,10 +33,9 @@ def load_ckpt(model, ckpt):
 
 
 def save_checkpoint(state, is_best, save_dir, model_name=""):
-    if not os.path.exists(save_dir):
-        os.makedirs(save_dir)
-    filename = os.path.join(save_dir, model_name + "_ckpt.pth")
+    save_dir.mkdir(parents=True, exist_ok=True)
+    filename = save_dir / f"{model_name}_ckpt.pth"
     torch.save(state, filename)
     if is_best:
-        best_filename = os.path.join(save_dir, "best_ckpt.pth")
-        shutil.copyfile(filename, best_filename)
+        best_filename = save_dir / "best_ckpt.pth"
+        shutil.copyfile(str(filename), str(best_filename))

--- a/yolox/utils/demo_utils.py
+++ b/yolox/utils/demo_utils.py
@@ -2,16 +2,9 @@
 # -*- coding:utf-8 -*-
 # Copyright (c) 2014-2021 Megvii Inc. All rights reserved.
 
-import os
-
 import numpy as np
 
-__all__ = ["mkdir", "nms", "multiclass_nms", "demo_postprocess"]
-
-
-def mkdir(path):
-    if not os.path.exists(path):
-        os.makedirs(path)
+__all__ = ["nms", "multiclass_nms", "demo_postprocess"]
 
 
 def nms(boxes, scores, nms_thr):

--- a/yolox/utils/dist.py
+++ b/yolox/utils/dist.py
@@ -100,11 +100,13 @@ def get_local_rank() -> int:
     Returns:
         The rank of the current process within the local (per-machine) process group.
     """
+    if _LOCAL_PROCESS_GROUP is None:
+        return get_rank()
+
     if not dist.is_available():
         return 0
     if not dist.is_initialized():
         return 0
-    assert _LOCAL_PROCESS_GROUP is not None
     return dist.get_rank(group=_LOCAL_PROCESS_GROUP)
 
 

--- a/yolox/utils/logger.py
+++ b/yolox/utils/logger.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2014-2021 Megvii Inc. All rights reserved.
 
 import inspect
-import os
+from pathlib import Path
 import sys
 from loguru import logger
 
@@ -63,7 +63,7 @@ def redirect_sys_output(log_level="INFO"):
 def setup_logger(save_dir, distributed_rank=0, filename="log.txt", mode="a"):
     """setup logger for training and testing.
     Args:
-        save_dir(str): location to save log file
+        save_dir(Path): location to save log file
         distributed_rank(int): device rank when multi-gpu environment
         filename (string): log save name.
         mode(str): log file write mode, `append` or `override`. default is `a`.
@@ -78,9 +78,10 @@ def setup_logger(save_dir, distributed_rank=0, filename="log.txt", mode="a"):
     )
 
     logger.remove()
-    save_file = os.path.join(save_dir, filename)
-    if mode == "o" and os.path.exists(save_file):
-        os.remove(save_file)
+    save_file = save_dir / filename
+    if mode == "o" and save_file.is_file():
+        save_file.unlink()
+
     # only keep logger in rank0 process
     if distributed_rank == 0:
         logger.add(

--- a/yolox/utils/logger.py
+++ b/yolox/utils/logger.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2014-2021 Megvii Inc. All rights reserved.
 
 import inspect
-from pathlib import Path
 import sys
 from loguru import logger
 


### PR DESCRIPTION
I noticed some issue with Windows due to the hardcoding of "/" in certain places. One example is when running: `python .\tools\demo.py video -n yolox-s -c ..\yolox_s.pth --path path\to\video\video_name  --conf 0.25  --nms 0.45 --tsize 640 - save_result --device gpu` the video containing the results overwrote my initial video and caused issues.

This was due to:
https://github.com/Megvii-BaseDetection/YOLOX/blob/25f116b3145db3f2808ffbe722677d301e34f40d/tools/demo.py#L219

There were a couple other places with hardcoded seperators so I changed to using pathlib to easily access the different parts of a path (using `parents` `stem` and `suffix` functions).

I think this makes the repo a little cleaner. Everything runs well on windows now.

Let me know what you think :)