### PR TITLE
chore: add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setuptools.setup(
     ],
     cmdclass={"build_ext": torch.utils.cpp_extension.BuildExtension},
     packages=setuptools.find_packages(),
+    include_package_data=True,
     project_urls={
         "Documentation": "https://yolox.readthedocs.io",
         "Source": "https://github.com/Megvii-BaseDetection/YOLOX",


### PR DESCRIPTION
`pip install yolox` causes this error below.
```
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/tmp/pip-install-xf7645yj/yolox_e7446ca202674d32b7f35c037579d088/setup.py", line 77, in <module>
      install_requires=get_install_requirements(),
    File "/tmp/pip-install-xf7645yj/yolox_e7446ca202674d32b7f35c037579d088/setup.py", line 49, in get_install_requirements
      with open("requirements.txt", "r", encoding="utf-8") as f:
  FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
```