### PR TITLE
FIx img_info returned from MosaicDetection.__getitem__()

### DIFF
--- a/yolox/data/datasets/mosaicdetection.py
+++ b/yolox/data/datasets/mosaicdetection.py
@@ -145,7 +145,7 @@ class MosaicDetection(Dataset):
             ):
                 mosaic_img, mosaic_labels = self.mixup(mosaic_img, mosaic_labels, self.input_dim)
             mix_img, padded_labels = self.preproc(mosaic_img, mosaic_labels, self.input_dim)
-            img_info = (mix_img.shape[1], mix_img.shape[0])
+            img_info = (mix_img.shape[1], mix_img.shape[2])
 
             # -----------------------------------------------------------------
             # img_info and img_id are not used for training.


### PR DESCRIPTION
At this line, a returned value `mix_img` basically has the shape of `(3, height, width)`
https://github.com/Megvii-BaseDetection/YOLOX/blob/237e943ac64aa32eb32f875faa93ebb18512d41d/yolox/data/datasets/mosaicdetection.py#L147
because `self.preproc()` here is typically `TrainTransform.__call__()` or `ValidTransform.__call__()` and these perform `transpose()` to convert `(height, width, 3)` into `(3, height, width)`.
https://github.com/Megvii-BaseDetection/YOLOX/blob/237e943ac64aa32eb32f875faa93ebb18512d41d/yolox/data/data_augment.py#L156
Thus, the current code of `MosaicDetection.__getitem__()` returns a tuple of `(height, 3)` always for any images, but that is supposed to be `(height, width)`.

This PR fixes this problem.