### PR TITLE
Disable autograd during TensorRT conversion

### DIFF
--- a/tools/trt.py
+++ b/tools/trt.py
@@ -35,6 +35,7 @@ def make_parser():
 
 
 @logger.catch
+@torch.no_grad()
 def main():
     args = make_parser().parse_args()
     exp = get_exp(args.exp_file, args.name)


### PR DESCRIPTION
torch2trt does a forward pass with the model and inputs and if autograd is not disabled it consumes a lot of memory to keep track of intermediary operation results for the backward pass. torch2trt never calls `backward()` so all that memory is used for nothing.

This PR disables autograd during Tensor RT conversion. This should particularly help conversion on edge devices with low memory and reduce the need to change the workspace size as in: #627, #756, #496, ...