### PR TITLE
An error about type conversion

### DIFF
--- a/yolox/data/datasets/voc.py
+++ b/yolox/data/datasets/voc.py
@@ -64,7 +64,7 @@ class AnnotationTransform(object):
             pts = ["xmin", "ymin", "xmax", "ymax"]
             bndbox = []
             for i, pt in enumerate(pts):
-                cur_pt = int(bbox.find(pt).text) - 1
+                cur_pt = int(float(bbox.find(pt).text)) - 1
                 # scale height or width
                 # cur_pt = cur_pt / width if i % 2 == 0 else cur_pt / height
                 bndbox.append(cur_pt)


### PR DESCRIPTION
Cause string of float like "100.1" can't change to int directly in python, so it will throw an error when the num of bbox is float in this code. Actually, I got the error when using and it can work after changing like this.