### PR TITLE
fix tiny config input_size

### DIFF
--- a/exps/default/yolox_tiny.py
+++ b/exps/default/yolox_tiny.py
@@ -12,7 +12,7 @@ class Exp(MyExp):
         super(Exp, self).__init__()
         self.depth = 0.33
         self.width = 0.375
-        self.input_scale = (416, 416)
+        self.input_size = (416, 416)
         self.mosaic_scale = (0.5, 1.5)
         self.random_size = (10, 20)
         self.test_size = (416, 416)


### PR DESCRIPTION
If used for single scale training, the input_size should be 416 in yolox_tiny.  
The input_scale looks like a typo, although it does not affect multi-scale training.
BTW, I think it's better to provide both multi-scale and single-scale training model modelzoo. 
Thanks.