### PR TITLE
Fix the error when running Yolox evaluation on COCO test-dev

### DIFF
--- a/yolox/data/datasets/coco.py
+++ b/yolox/data/datasets/coco.py
@@ -27,8 +27,9 @@ def remove_useless_info(coco):
             img.pop("coco_url", None)
             img.pop("date_captured", None)
             img.pop("flickr_url", None)
-        for anno in coco.dataset["annotations"]:
-            anno.pop("segmentation", None)
+        if "annotations" in coco.dataset:
+            for anno in coco.dataset["annotations"]:
+                anno.pop("segmentation", None)
 
 
 class COCODataset(Dataset):


### PR DESCRIPTION
This allows the following command to be run without error when database and config files are deployed:
"python -m yolox.tools.eval -n  yolox-s -c yolox_s.pth -b 64 --conf 0.001 -d 1 --test"
