### PR TITLE
added ability to show YOLOX demo in live window

### DIFF
--- a/tools/demo.py
+++ b/tools/demo.py
@@ -211,18 +211,19 @@ def imageflow_demo(predictor, vis_folder, current_time, args):
     width = cap.get(cv2.CAP_PROP_FRAME_WIDTH)  # float
     height = cap.get(cv2.CAP_PROP_FRAME_HEIGHT)  # float
     fps = cap.get(cv2.CAP_PROP_FPS)
-    save_folder = os.path.join(
-        vis_folder, time.strftime("%Y_%m_%d_%H_%M_%S", current_time)
-    )
-    os.makedirs(save_folder, exist_ok=True)
-    if args.demo == "video":
-        save_path = os.path.join(save_folder, os.path.basename(args.path))
-    else:
-        save_path = os.path.join(save_folder, "camera.mp4")
-    logger.info(f"video save_path is {save_path}")
-    vid_writer = cv2.VideoWriter(
-        save_path, cv2.VideoWriter_fourcc(*"mp4v"), fps, (int(width), int(height))
-    )
+    if args.save_result:
+        save_folder = os.path.join(
+            vis_folder, time.strftime("%Y_%m_%d_%H_%M_%S", current_time)
+        )
+        os.makedirs(save_folder, exist_ok=True)
+        if args.demo == "video":
+            save_path = os.path.join(save_folder, os.path.basename(args.path))
+        else:
+            save_path = os.path.join(save_folder, "camera.mp4")
+        logger.info(f"video save_path is {save_path}")
+        vid_writer = cv2.VideoWriter(
+            save_path, cv2.VideoWriter_fourcc(*"mp4v"), fps, (int(width), int(height))
+        )
     while True:
         ret_val, frame = cap.read()
         if ret_val:
@@ -230,6 +231,9 @@ def imageflow_demo(predictor, vis_folder, current_time, args):
             result_frame = predictor.visual(outputs[0], img_info, predictor.confthre)
             if args.save_result:
                 vid_writer.write(result_frame)
+            else:
+                cv2.namedWindow("yolox", cv2.WINDOW_NORMAL)
+                cv2.imshow("yolox", result_frame)
             ch = cv2.waitKey(1)
             if ch == 27 or ch == ord("q") or ch == ord("Q"):
                 break


### PR DESCRIPTION
This PR adds the possibility to run YOLOX live on web camera - showing the detections in a "live" window. I had to do some minor fixes as it always changed the save-path even it was not intended to save the results. Therefore the PR is somewhat bigger than needed - so it also fix a minor other issue.

` python tools/demo.py webcam -n yolox-l -c yolox_l.pth --camid 0 --conf 0.25 --nms 0.45 --tsize 640 --device cpu`

Will now give a result like this (running on a GPU less MacBook):

<img width="978" alt="image" src="https://user-images.githubusercontent.com/599447/154839860-438817c8-fa8e-4543-92b8-1b0c703569f0.png">

