### PR TITLE
fix(utils): occupy_mem based on CUDA_VISIBLE_DEVICES

### DIFF
--- a/yolox/utils/metric.py
+++ b/yolox/utils/metric.py
@@ -24,6 +24,9 @@ def get_total_and_free_memory_in_Mb(cuda_device):
         "nvidia-smi --query-gpu=memory.total,memory.used --format=csv,nounits,noheader"
     )
     devices_info = devices_info_str.read().strip().split("\n")
+    if "CUDA_VISIBLE_DEVICES" in os.environ:
+        visible_devices = os.environ["CUDA_VISIBLE_DEVICES"].split(',')
+        cuda_device = int(visible_devices[cuda_device])
     total, used = devices_info[int(cuda_device)].split(",")
     return int(total), int(used)
 


### PR DESCRIPTION
When we set enviroment variable `CUDA_VISIBLE_DEVICES`, pytorch sees only specified gpus and [`get_total_and_free_memory_in_Mb(cuda_device)`](https://github.com/Megvii-BaseDetection/YOLOX/blob/57309c730d9f8c0dd1496706886ec00ddc8a11d2/yolox/utils/metric.py#L22) doesn't work properly.

For example, let `CUDA_VISIBLE_DEVICES=2`. [`get_local_rank()`](https://github.com/Megvii-BaseDetection/YOLOX/blob/57309c730d9f8c0dd1496706886ec00ddc8a11d2/yolox/utils/dist.py#L98) will return 0. It makes [`get_total_and_free_memory_in_Mb(cuda_device)`](https://github.com/Megvii-BaseDetection/YOLOX/blob/57309c730d9f8c0dd1496706886ec00ddc8a11d2/yolox/utils/metric.py#L22) measure memory of zero gpu, not the second. If gpu 0 is occupied by other process, the error occurs, like in #193, #346, #438 