### PR TITLE
Adding support for wandb

### DIFF
--- a/docs/quick_run.md
+++ b/docs/quick_run.md
@@ -56,6 +56,26 @@ python tools/train.py -n yolox-s -d 8 -b 64 --fp16 -o [--cache]
 * --fp16: mixed precision training
 * --cache: caching imgs into RAM to accelarate training, which need large system RAM.
 
+**Weights & Biases for Logging**
+
+To use W&B for logging, install wandb in your environment and log in to your W&B account using
+
+```shell
+pip install wandb
+wandb login
+```
+
+Log in to your W&B account
+
+To start logging metrics to W&B during training add the flag `--logger` to the previous command and use the prefix "wandb-" to specify arguments for initializing the wandb run.
+
+```shell
+python tools/train.py -n yolox-s -d 8 -b 64 --fp16 -o [--cache] --logger wandb wandb-project <project name>
+                         yolox-m
+                         yolox-l
+                         yolox-x
+```
+
 **Multi Machine Training**
 
 We also support multi-nodes training. Just add the following args:

--- a/tools/train.py
+++ b/tools/train.py
@@ -81,6 +81,13 @@ def make_parser():
         help="occupy GPU memory first for training.",
     )
     parser.add_argument(
+        "-l",
+        "--logger",
+        type=str,
+        help="Logger to be used for metrics",
+        default="tensorboard"
+    )
+    parser.add_argument(
         "opts",
         help="Modify config options using the command-line",
         default=None,

--- a/yolox/core/trainer.py
+++ b/yolox/core/trainer.py
@@ -15,6 +15,7 @@ from yolox.data import DataPrefetcher
 from yolox.utils import (
     MeterBuffer,
     ModelEMA,
+    WandbLogger,
     all_reduce_norm,
     get_local_rank,
     get_model_info,
@@ -26,7 +27,6 @@ from yolox.utils import (
     occupy_mem,
     save_checkpoint,
     setup_logger,
-    WandbLogger,
     synchronize
 )
 
@@ -361,5 +361,5 @@ class Trainer:
                 ckpt_name,
             )
 
-            if self.args.logger == 'wandb':
+            if self.args.logger == "wandb":
                 self.wandb_logger.save_checkpoint(self.file_name, ckpt_name, update_best_ckpt)

--- a/yolox/core/trainer.py
+++ b/yolox/core/trainer.py
@@ -184,6 +184,8 @@ class Trainer:
                     if k.startswith("wandb-"):
                         wandb_params.update({k.lstrip("wandb-"): v})
                 self.wandb_logger = WandbLogger(config=vars(self.exp), **wandb_params)
+            else:
+                raise ValueError("logger must be either 'tensorboard' or 'wandb'")
 
         logger.info("Training start...")
         logger.info("\n{}".format(model))

--- a/yolox/core/trainer.py
+++ b/yolox/core/trainer.py
@@ -192,8 +192,9 @@ class Trainer:
         logger.info(
             "Training of experiment is done and the best AP is {:.2f}".format(self.best_ap * 100)
         )
-        if self.args.logger == "wandb":
-            self.wandb_logger.finish()
+        if self.rank == 0:
+            if self.args.logger == "wandb":
+                self.wandb_logger.finish()
 
     def before_epoch(self):
         logger.info("---> start train epoch{}".format(self.epoch + 1))
@@ -357,3 +358,6 @@ class Trainer:
                 self.file_name,
                 ckpt_name,
             )
+
+            if self.args.logger == 'wandb':
+                self.wandb_logger.save_checkpoint(self.file_name, ckpt_name, update_best_ckpt)

--- a/yolox/utils/__init__.py
+++ b/yolox/utils/__init__.py
@@ -8,7 +8,7 @@ from .checkpoint import load_ckpt, save_checkpoint
 from .demo_utils import *
 from .dist import *
 from .ema import *
-from .logger import setup_logger, WandbLogger
+from .logger import WandbLogger, setup_logger
 from .lr_scheduler import LRScheduler
 from .metric import *
 from .model_utils import *

--- a/yolox/utils/__init__.py
+++ b/yolox/utils/__init__.py
@@ -8,7 +8,7 @@ from .checkpoint import load_ckpt, save_checkpoint
 from .demo_utils import *
 from .dist import *
 from .ema import *
-from .logger import setup_logger
+from .logger import setup_logger, WandbLogger
 from .lr_scheduler import LRScheduler
 from .metric import *
 from .model_utils import *

--- a/yolox/utils/logger.py
+++ b/yolox/utils/logger.py
@@ -95,6 +95,15 @@ def setup_logger(save_dir, distributed_rank=0, filename="log.txt", mode="a"):
     redirect_sys_output("INFO")
 
 class WandbLogger(object):
+    """
+    Log training runs, datasets, models, and predictions to Weights & Biases.
+    This logger sends information to W&B at wandb.ai. By default, this information
+    includes hyperparameters, system configuration and metrics, model metrics,
+    and basic data metrics and analyses.
+
+    For more information, please refer to:
+    https://docs.wandb.ai/
+    """
     def __init__(self, project=None, name=None, id=None, save_dir=None, config=None, **kwargs):
         """
         Args:

--- a/yolox/utils/logger.py
+++ b/yolox/utils/logger.py
@@ -6,6 +6,7 @@ import inspect
 import os
 import sys
 from loguru import logger
+
 import torch
 
 

--- a/yolox/utils/logger.py
+++ b/yolox/utils/logger.py
@@ -8,10 +8,12 @@ import sys
 from loguru import logger
 import torch
 
+
 def get_caller_name(depth=0):
     """
     Args:
-        depth (int): Depth of caller conext, use 0 for caller depth. Default value: 0.
+        depth (int): Depth of caller conext, use 0 for caller depth.
+        Default value: 0.
 
     Returns:
         str: module name of the caller
@@ -94,23 +96,32 @@ def setup_logger(save_dir, distributed_rank=0, filename="log.txt", mode="a"):
     # redirect stdout/stderr to loguru
     redirect_sys_output("INFO")
 
+
 class WandbLogger(object):
     """
     Log training runs, datasets, models, and predictions to Weights & Biases.
-    This logger sends information to W&B at wandb.ai. By default, this information
-    includes hyperparameters, system configuration and metrics, model metrics,
+    This logger sends information to W&B at wandb.ai.
+    By default, this information includes hyperparameters,
+    system configuration and metrics, model metrics,
     and basic data metrics and analyses.
 
     For more information, please refer to:
     https://docs.wandb.ai/guides/track
     """
-    def __init__(self, project=None, name=None, id=None, entity=None, save_dir=None, config=None, **kwargs):
+    def __init__(self,
+                 project=None,
+                 name=None,
+                 id=None,
+                 entity=None,
+                 save_dir=None,
+                 config=None,
+                 **kwargs):
         """
         Args:
             project (str): wandb project name.
             name (str): wandb run name.
             id (str): wandb run id.
-            entity (str): wandb entity name.ßß
+            entity (str): wandb entity name.
             save_dir (str): save directory.
             config (dict): config dict.
             **kwargs: other kwargs.
@@ -118,8 +129,11 @@ class WandbLogger(object):
         try:
             import wandb
             self.wandb = wandb
-        except:
-            raise ModuleNotFoundError("wandb is not installed. Please install wandb using pip install wandb")
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                "wandb is not installed."
+                "Please install wandb using pip install wandb"
+                )
 
         self.project = project
         self.name = name
@@ -143,23 +157,24 @@ class WandbLogger(object):
 
         if self.config:
             self.run.config.update(self.config)
-        
         self.run.define_metric("epoch")
         self.run.define_metric("val/", step_metric="epoch")
-    
+
     @property
     def run(self):
         if self._run is None:
             if self.wandb.run is not None:
                 logger.info(
-                    "There is a wandb run already in progress and newly created instances of `WandbLogger` will reuse"
-                    " this run. If this is not desired, call `wandb.finish()` before instantiating `WandbLogger`."
+                    "There is a wandb run already in progress "
+                    "and newly created instances of `WandbLogger` will reuse"
+                    " this run. If this is not desired, call `wandb.finish()`"
+                    "before instantiating `WandbLogger`."
                 )
                 self._run = self.wandb.run
             else:
                 self._run = self.wandb.init(**self._wandb_init)
         return self._run
-    
+
     def log_metrics(self, metrics, step=None):
         """
         Args:
@@ -184,7 +199,10 @@ class WandbLogger(object):
             is_best (bool): whether the model is the best model.
         """
         filename = os.path.join(save_dir, model_name + "_ckpt.pth")
-        artifact = self.wandb.Artifact(name=f"model-{self.run.id}", type="model")
+        artifact = self.wandb.Artifact(
+            name=f"model-{self.run.id}",
+            type="model"
+        )
         artifact.add_file(filename, name="model_ckpt.pth")
 
         aliases = ["latest"]

--- a/yolox/utils/logger.py
+++ b/yolox/utils/logger.py
@@ -164,5 +164,23 @@ class WandbLogger(object):
         else:
             self.run.log(metrics)
 
+    def save_checkpoint(self, save_dir, model_name, is_best):
+        """
+        Args:
+            save_dir (str): save directory.
+            model_name (str): model name.
+            is_best (bool): whether the model is the best model.
+        """
+        filename = os.path.join(save_dir, model_name + "_ckpt.pth")
+        artifact = self.wandb.Artifact(name=f"model-{self.run.id}", type="model")
+        artifact.add_file(filename, name="model_ckpt.pth")
+
+        aliases = ["latest"]
+
+        if is_best:
+            aliases.append("best")
+
+        self.run.log_artifact(artifact, aliases=aliases)
+
     def finish(self):
         self.run.finish()

--- a/yolox/utils/logger.py
+++ b/yolox/utils/logger.py
@@ -102,14 +102,15 @@ class WandbLogger(object):
     and basic data metrics and analyses.
 
     For more information, please refer to:
-    https://docs.wandb.ai/
+    https://docs.wandb.ai/guides/track
     """
-    def __init__(self, project=None, name=None, id=None, save_dir=None, config=None, **kwargs):
+    def __init__(self, project=None, name=None, id=None, entity=None, save_dir=None, config=None, **kwargs):
         """
         Args:
             project (str): wandb project name.
             name (str): wandb run name.
             id (str): wandb run id.
+            entity (str): wandb entity name.ßß
             save_dir (str): save directory.
             config (dict): config dict.
             **kwargs: other kwargs.
@@ -126,11 +127,13 @@ class WandbLogger(object):
         self.save_dir = save_dir
         self.config = config
         self.kwargs = kwargs
+        self.entity = entity
         self._run = None
         self._wandb_init = dict(
             project=self.project,
             name=self.name,
             id=self.id,
+            entity=self.entity,
             dir=self.save_dir,
             resume="allow"
         )

--- a/yolox/utils/logger.py
+++ b/yolox/utils/logger.py
@@ -6,7 +6,7 @@ import inspect
 import os
 import sys
 from loguru import logger
-
+import torch
 
 def get_caller_name(depth=0):
     """
@@ -93,3 +93,76 @@ def setup_logger(save_dir, distributed_rank=0, filename="log.txt", mode="a"):
 
     # redirect stdout/stderr to loguru
     redirect_sys_output("INFO")
+
+class WandbLogger(object):
+    def __init__(self, project=None, name=None, id=None, save_dir=None, config=None, **kwargs):
+        """
+        Args:
+            project (str): wandb project name.
+            name (str): wandb run name.
+            id (str): wandb run id.
+            save_dir (str): save directory.
+            config (dict): config dict.
+            **kwargs: other kwargs.
+        """
+        try:
+            import wandb
+            self.wandb = wandb
+        except:
+            raise ModuleNotFoundError("wandb is not installed. Please install wandb using pip install wandb")
+
+        self.project = project
+        self.name = name
+        self.id = id
+        self.save_dir = save_dir
+        self.config = config
+        self.kwargs = kwargs
+        self._run = None
+        self._wandb_init = dict(
+            project=self.project,
+            name=self.name,
+            id=self.id,
+            dir=self.save_dir,
+            resume="allow"
+        )
+        self._wandb_init.update(**kwargs)
+
+        _ = self.run
+
+        if self.config:
+            self.run.config.update(self.config)
+        
+        self.run.define_metric("epoch")
+        self.run.define_metric("val/", step_metric="epoch")
+    
+    @property
+    def run(self):
+        if self._run is None:
+            if self.wandb.run is not None:
+                logger.info(
+                    "There is a wandb run already in progress and newly created instances of `WandbLogger` will reuse"
+                    " this run. If this is not desired, call `wandb.finish()` before instantiating `WandbLogger`."
+                )
+                self._run = self.wandb.run
+            else:
+                self._run = self.wandb.init(**self._wandb_init)
+        return self._run
+    
+    def log_metrics(self, metrics, step=None):
+        """
+        Args:
+            metrics (dict): metrics dict.
+            step (int): step number.
+        """
+
+        for k, v in metrics.items():
+            if isinstance(v, torch.Tensor):
+                metrics[k] = v.item()
+
+        if step is not None:
+            self.run.log(metrics, step=step)
+        else:
+            self.run.log(metrics)
+
+    def finish(self):
+        self.run.finish()


### PR DESCRIPTION
This PR fixes issues #1030 and #1049 . It adds support for the wandb logger.
I've added a new command line argument `--logger` which accepts "tensorboard" and "wandb" as arguments and raises an error otherwise.
More wandb related arguments like `project`, `entity` etc. can be provided in the CLI using the prefix `wandb-`. For example

```shell
python tools/train.py -n yolox-s -d 8 -b 64 --fp16 -o [--cache] --logger wandb wandb-project <project name>
                         yolox-m
                         yolox-l
                         yolox-x
```

All the metrics are logged to the W&B dashboard along with the hyperparameters. The model checkpoints are stored as wandb artifacts along with tagging the best and latest models appropriately.

[This dashboard](https://wandb.ai/manan-goel/yolox-s/runs/1mg3zu90) uses yolox-tiny.