### PR TITLE
Fix logging.h for Jetson

### DIFF
--- a/demo/TensorRT/cpp/logging.h
+++ b/demo/TensorRT/cpp/logging.h
@@ -236,7 +236,7 @@ public:
     //! Note samples should not be calling this function directly; it will eventually go away once we eliminate the
     //! inheritance from nvinfer1::ILogger
     //!
-    void log(Severity severity, const char* msg) override
+    void log(Severity severity, const char* msg) noexcept override
     {
         LogStreamConsumer(mReportableSeverity, severity) << "[TRT] " << std::string(msg) << std::endl;
     }


### PR DESCRIPTION
Hello, I'm maintaining [YOLOX-ROS](https://github.com/Ar-Ray-code/YOLOX-ROS).
I open a pull request to suggest additional support for Jetson + [TensorRT-C++ demo](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/demo/TensorRT/cpp), error in the demo program and how to work that.

---

## Current Bug

### version

- Board : Jetson Nano
- Jetpack : 32.6.1 (Ubuntu 18.04, CUDA 10.2)

![scrt_jetson](https://user-images.githubusercontent.com/67567093/160393833-f3bbeb3b-5595-44ea-aec2-ef50da62c03a.png)

## solution

Modify [logging.h](https://github.com/Megvii-BaseDetection/YOLOX/blob/main/demo/TensorRT/cpp/logging.h#L239) according to the URL.

https://forums.developer.nvidia.com/t/looser-throw-specifier-for-virtual-void-logger-log/187963

This is a very minor correction, but please correct it for the sake of beginners. :)