### PR TITLE
Add options to output COCO-style prediction json

### DIFF
--- a/tools/eval.py
+++ b/tools/eval.py
@@ -97,6 +97,16 @@ def make_parser():
         help="speed test only.",
     )
     parser.add_argument(
+        "--coco_out_dir",
+        help="Output folder for MSCOCO prediction json.",
+        default=None,
+    )
+    parser.add_argument(
+        "--coco_out_name",
+        help="File name for MSCOCO prediction json.",
+        default=None,
+    )
+    parser.add_argument(
         "opts",
         help="Modify config options using the command-line",
         default=None,
@@ -181,10 +191,14 @@ def main(exp, args, num_gpu):
     else:
         trt_file = None
         decoder = None
-
+    
+    if args.coco_out_dir != None:
+        os.makedirs(args.coco_out_dir, exist_ok=True) 
+        coco_out_path = os.path.join(args.coco_out_dir, args.coco_out_name)
+        
     # start evaluate
     *_, summary = evaluator.evaluate(
-        model, is_distributed, args.fp16, trt_file, decoder, exp.test_size
+        model, is_distributed, args.fp16, trt_file, decoder, exp.test_size, coco_out_path
     )
     logger.info("\n" + summary)
 

--- a/yolox/evaluators/coco_evaluator.py
+++ b/yolox/evaluators/coco_evaluator.py
@@ -91,7 +91,6 @@ class COCOEvaluator:
         testdev: bool = False,
         per_class_AP: bool = False,
         per_class_AR: bool = False,
-#         class_names: list = None,
     ):
         """
         Args:


### PR DESCRIPTION
This pull request allows users to output COCO-style prediction JSON by setting the arguments:
1. coco_out_dir : "Output folder for MSCOCO prediction json."
2. coco_out_name : "File name for MSCOCO prediction json."

