### PR TITLE
fix: Link to `yolox_base.py`

### DIFF
--- a/docs/train_custom_data.md
+++ b/docs/train_custom_data.md
@@ -41,7 +41,7 @@ ln -s /path/to/your/VOCdevkit ./datasets/VOCdevkit
 ## 2. Create your Exp file to control everything
 We put everything involved in a model to one single Exp file, including model setting, training setting, and testing setting.
 
-**A complete Exp file is at [yolox_base.py](https://github.com/Megvii-BaseDetection/YOLOX/blob/main/yolox/exp/base_exp.py).** It may be too long to write for every exp, but you can inherit the base Exp file and only overwrite the changed part.
+**A complete Exp file is at [yolox_base.py](https://github.com/Megvii-BaseDetection/YOLOX/blob/main/yolox/exp/yolox_base.py).** It may be too long to write for every exp, but you can inherit the base Exp file and only overwrite the changed part.
 
 Let's take the [VOC Exp file](https://github.com/Megvii-BaseDetection/YOLOX/blob/main/exps/example/yolox_voc/yolox_voc_s.py) as an example.
 


### PR DESCRIPTION
Correction of URL pointing to `base_exp.py` instead of `yolox_base.py`