### PR TITLE
Fix fusion of convolution and batch normalization layers not preserving dtype

### DIFF
--- a/yolox/utils/model_utils.py
+++ b/yolox/utils/model_utils.py
@@ -55,6 +55,7 @@ def fuse_conv_and_bn(conv: nn.Conv2d, bn: nn.BatchNorm2d) -> nn.Conv2d:
         )
         .requires_grad_(False)
         .to(conv.weight.device)
+        .to(conv.weight.dtype)
     )
 
     # prepare filters
@@ -64,7 +65,7 @@ def fuse_conv_and_bn(conv: nn.Conv2d, bn: nn.BatchNorm2d) -> nn.Conv2d:
 
     # prepare spatial bias
     b_conv = (
-        torch.zeros(conv.weight.size(0), device=conv.weight.device)
+        conv.weight.new_zeros(conv.weight.size(0))
         if conv.bias is None
         else conv.bias
     )


### PR DESCRIPTION
Fixes the error:
```
Traceback (most recent call last):
  File "tools/demo.py", line 320, in <module>
    main(exp, args)
  File "tools/demo.py", line 290, in main
    model = fuse_model(model)
  File "YOLOX/yolox/utils/model_utils.py", line 92, in fuse_model
    m.conv = fuse_conv_and_bn(m.conv, m.bn)  # update conv
  File "YOLOX/yolox/utils/model_utils.py", line 74, in fuse_conv_and_bn
    fusedconv.bias.copy_(torch.mm(w_bn, b_conv.reshape(-1, 1)).reshape(-1) + b_bn)
RuntimeError: expected scalar type Half but found Float
```

when using `--fp16 --fuse`. To replicate the issue, run the command:
```sh
python tools/demo.py image -n yolox-tiny -c yolox_tiny.pth --device gpu --conf 0.01 --fp16 --fuse
```