### PR TITLE
Fix merge of boolean experiment variables with string from CLI

### DIFF
--- a/yolox/exp/base_exp.py
+++ b/yolox/exp/base_exp.py
@@ -68,8 +68,20 @@ class BaseExp(metaclass=ABCMeta):
                 src_value = getattr(self, k)
                 src_type = type(src_value)
                 if src_value is not None and src_type != type(v):
-                    try:
-                        v = src_type(v)
-                    except Exception:
-                        v = ast.literal_eval(v)
+                    if isinstance(src_value, bool):
+                        # Booleans are a special case because src_type(v) is equivalent
+                        # to bool(v). For v = "False", bool("False") = True which is not
+                        # the expected result
+                        words = ("true", "1", "false", "0")
+                        if v.lower() in words:
+                            v = v.lower() in ("true", "1")
+                        else:
+                            raise RuntimeError(
+                                f"Cannot cast '{v}' to bool. Expect one of {words}"
+                            )
+                    else:
+                        try:
+                            v = src_type(v)
+                        except Exception:
+                            v = ast.literal_eval(v)
                 setattr(self, k, v)


### PR DESCRIPTION
This PR fixes boolean conversion from CLI strings when merging with experiment configuration.

This is the current behavior:
```
python tools/train.py ... save_history_ckpt False
```
results in `self.save_history_ckpt=True` because the function `merge()` executes the following code:

`v = src_type(v)` -> `self.save_history_ckpt = bool("False")` -> `self.save_history_ckpt = True`

In Python, any non-empty string when cast to bool returns `True`.

Naturally, the expected behavior is actually `self.save_history_ckpt = False`.