### PR TITLE
Implement break-down mode for cross entropy calculation

### DIFF
--- a/yolox/models/yolo_head.py
+++ b/yolox/models/yolo_head.py
@@ -487,11 +487,12 @@ class YOLOXHead(nn.Module):
 
         with torch.cuda.amp.autocast(enabled=False):
             cls_preds_ = (
-                cls_preds_.float().unsqueeze(0).repeat(num_gt, 1, 1).sigmoid_()
-                * obj_preds_.float().unsqueeze(0).repeat(num_gt, 1, 1).sigmoid_()
-            )
+                cls_preds_.float().unsqueeze(0).sigmoid_()
+                * obj_preds_.float().unsqueeze(0).sigmoid_()
+            ).sqrt_()
             pair_wise_cls_loss = F.binary_cross_entropy(
-                cls_preds_.sqrt_(), gt_cls_per_image, reduction="none"
+                cls_preds_.repeat(num_gt, 1, 1), gt_cls_per_image,
+                reduction="none"
             ).sum(-1)
         del cls_preds_
 


### PR DESCRIPTION
This PR prevents the training process from falling down to the CPU mode, possibly happens in following case.

- large number of objects per image (detected and ground truth)
- large number of classes

When calculating cross entropy, the process requires a tensor with following size
`nr_of_detected_objects * nr_of_ground_truth * nr_of_classes`
which may explode in the above case and cause GPU OOM.

This PR implements break-down mode of cross entropy calculation, which requires only
`nr_of_detected_objects * nr_of_classes`
of tensor. This mode will be tried when the original code caused OOM, and still runs far faster than the CPU mode.

For testing, you can pull the following branch
https://github.com/penkoba/YOLOX/tree/break_down_cross_entropy_calc-test
and run `test-train.sh`, then you may see entering the break-down mode but still runs at acceptable speed.
Without this PR, the traning process falls into CPU mode very often and gets very slow.
(tested with RTX 2080 Ti)