### PR TITLE
fix(hubconf): installing missing requirements when torch.hub.load

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -6,7 +6,10 @@ Usage example:
     import torch
     model = torch.hub.load("Megvii-BaseDetection/YOLOX", "yolox_s")
 """
-dependencies = ["torch"]
+from yolox.utils.hub import ensure_installed
+
+HUB_REQUIREMENTS = ["loguru", "torchvision", "thop", "opencv-python-headless==4.5.2.52", "tabulate"]
+ensure_installed(HUB_REQUIREMENTS)
 
 from yolox.models import (  # isort:skip  # noqa: F401, E402
     yolox_tiny,

--- a/yolox/utils/hub.py
+++ b/yolox/utils/hub.py
@@ -1,0 +1,24 @@
+from logging import info, basicConfig, INFO
+from subprocess import check_output
+from typing import List
+
+import pkg_resources as pkg
+
+
+def ensure_installed(requirements: List[str]) -> None:
+    """
+        Checks for required packages and installs them if possible
+
+        Args:
+            requirements: list of required python packages
+
+        Returns:
+            None
+    """
+    for requirement in requirements:
+        try:
+            pkg.require(requirement)
+        except Exception:
+            basicConfig(format="%(message)s", level=INFO)
+            info(f"Requirement {requirement} was not found. Trying to install...")
+            info(check_output(f"pip install {requirement}", shell=True).decode())


### PR DESCRIPTION
Fixed https://github.com/Megvii-BaseDetection/YOLOX/issues/1272 by autoinstalling essential packages 