### PR TITLE
upgrade onnxsim to v0.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ tabulate
 pycocotools>=2.0.2
 onnx==1.8.1
 onnxruntime==1.8.0
-onnx-simplifier==0.3.5
+onnx-simplifier==0.4.1

--- a/tools/export_onnx.py
+++ b/tools/export_onnx.py
@@ -103,7 +103,7 @@ def main():
     if not args.no_onnxsim:
         import onnx
         from onnxsim import simplify
-        
+
         # use onnx-simplifier to reduce reduent model.
         onnx_model = onnx.load(args.output_name)
         model_simp, check = simplify(onnx_model)

--- a/tools/export_onnx.py
+++ b/tools/export_onnx.py
@@ -102,16 +102,11 @@ def main():
 
     if not args.no_onnxsim:
         import onnx
-
         from onnxsim import simplify
-
-        input_shapes = {args.input: list(dummy_input.shape)} if args.dynamic else None
-
-        # use onnxsimplify to reduce reduent model.
+        
+        # use onnx-simplifier to reduce reduent model.
         onnx_model = onnx.load(args.output_name)
-        model_simp, check = simplify(onnx_model,
-                                     dynamic_input_shape=args.dynamic,
-                                     input_shapes=input_shapes)
+        model_simp, check = simplify(onnx_model)
         assert check, "Simplified ONNX model could not be validated"
         onnx.save(model_simp, args.output_name)
         logger.info("generated simplified onnx model named {}".format(args.output_name))


### PR DESCRIPTION
I'm the author of onnx-simplifier. Recently I published onnxsim v0.4.1. In the latest version, dynamic input shapes are natively supported with no need for extra flags like `dynamic_input_shapes` and `input_shapes`.