### PR TITLE
Add option decode_in_inference to export_torchscript

### DIFF
--- a/tools/export_torchscript.py
+++ b/tools/export_torchscript.py
@@ -33,6 +33,11 @@ def make_parser():
         default=None,
         nargs=argparse.REMAINDER,
     )
+    parser.add_argument(
+        "--decode_in_inference",
+        action="store_true",
+        help="decode in inference or not"
+    )
 
     return parser
 
@@ -61,7 +66,7 @@ def main():
     if "model" in ckpt:
         ckpt = ckpt["model"]
     model.load_state_dict(ckpt)
-    model.head.decode_in_inference = False
+    model.head.decode_in_inference = args.decode_in_inference
 
     logger.info("loading checkpoint done.")
     dummy_input = torch.randn(args.batch_size, 3, exp.test_size[0], exp.test_size[1])

--- a/tools/export_torchscript.py
+++ b/tools/export_torchscript.py
@@ -28,15 +28,15 @@ def make_parser():
     parser.add_argument("-n", "--name", type=str, default=None, help="model name")
     parser.add_argument("-c", "--ckpt", default=None, type=str, help="ckpt path")
     parser.add_argument(
+        "--decode_in_inference",
+        action="store_true",
+        help="decode in inference or not"
+    )
+    parser.add_argument(
         "opts",
         help="Modify config options using the command-line",
         default=None,
         nargs=argparse.REMAINDER,
-    )
-    parser.add_argument(
-        "--decode_in_inference",
-        action="store_true",
-        help="decode in inference or not"
     )
 
     return parser


### PR DESCRIPTION
I would like to add the `decode_in_inference` option to export_torchscript.py. The reason is the same as #1113.
I have confirmed that it can be converted torchscript properly with this option set to True.

Can you please review this PR?