### PR TITLE
Remove dynamic_ks.tolist() task

### DIFF
--- a/yolox/models/yolo_head.py
+++ b/yolox/models/yolo_head.py
@@ -617,7 +617,6 @@ class YOLOXHead(nn.Module):
         n_candidate_k = min(10, ious_in_boxes_matrix.size(1))
         topk_ious, _ = torch.topk(ious_in_boxes_matrix, n_candidate_k, dim=1)
         dynamic_ks = torch.clamp(topk_ious.sum(1).int(), min=1)
-        dynamic_ks = dynamic_ks.tolist()
         for gt_idx in range(num_gt):
             _, pos_idx = torch.topk(
                 cost[gt_idx], k=dynamic_ks[gt_idx], largest=False


### PR DESCRIPTION
Why do we change the type of `dynamic_ks` to list?

https://github.com/Megvii-BaseDetection/YOLOX/blob/c4298f800d99ddc930267d8503d49b4dc06cff48/yolox/models/yolo_head.py#L619-L627