### PR TITLE
Optimize decode_outputs for OpenVINO IR

### DIFF
--- a/yolox/models/yolo_head.py
+++ b/yolox/models/yolo_head.py
@@ -246,8 +246,7 @@ class YOLOXHead(nn.Module):
         grids = torch.cat(grids, dim=1).type(dtype)
         strides = torch.cat(strides, dim=1).type(dtype)
 
-        outputs[..., :2] = (outputs[..., :2] + grids) * strides
-        outputs[..., 2:4] = torch.exp(outputs[..., 2:4]) * strides
+        outputs = torch.cat([(outputs[..., 0:2] + grids) * strides, torch.exp(outputs[..., 2:4]) * strides, outputs[..., 4:]], dim=-1)
         return outputs
 
     def get_losses(


### PR DESCRIPTION
Replace `ScatterND` ops that will cause error in openvino model optimizer with more acceptable `Concat`. Now you can embed decoder into OpenVINO Intermediate Representation format (IR), which you can infer later with OpenVINO™ Runtime.