### PR TITLE
Replace numpy indexing with PyTorch's index_select()

### DIFF
--- a/yolox/utils/boxes.py
+++ b/yolox/utils/boxes.py
@@ -67,7 +67,8 @@ def postprocess(prediction, num_classes, conf_thre=0.7, nms_thre=0.45, class_agn
                 nms_thre,
             )
 
-        detections = detections[nms_out_index]
+        detections = torch.index_select(input=detections, dim=0, index=nms_out_index)
+
         if output[i] is None:
             output[i] = detections
         else:

--- a/yolox/utils/boxes.py
+++ b/yolox/utils/boxes.py
@@ -30,7 +30,7 @@ def filter_box(output, scale_range):
 
 
 def postprocess(prediction, num_classes, conf_thre=0.7, nms_thre=0.45, class_agnostic=False):
-    box_corner = prediction.new(prediction.shape)
+    box_corner = torch.zeros_like(prediction)
     box_corner[:, :, 0] = prediction[:, :, 0] - prediction[:, :, 2] / 2
     box_corner[:, :, 1] = prediction[:, :, 1] - prediction[:, :, 3] / 2
     box_corner[:, :, 2] = prediction[:, :, 0] + prediction[:, :, 2] / 2


### PR DESCRIPTION
This PR suggests using PyTorch's own index_select() function to avoid indexing errors. "Index out of bounds" errors occurred when the non-maximum suppression returned multiple indices. In this case, the indices do not seem to be interpreted as accessing a set of elements along the same dimension, but rather as accessing a single element in the tensor. So far, this issue has only occurred with models converted to TensorRT. Using PyTorch's index_select() function instead of Numpy indexing fixes the symptom.