### PR TITLE
fix(head): fix no-candidate anchor issue for tiny objects during label assignment

### DIFF
--- a/yolox/models/yolo_head.py
+++ b/yolox/models/yolo_head.py
@@ -555,7 +555,7 @@ class YOLOXHead(nn.Module):
         is_in_centers = center_deltas.min(dim=-1).values > 0.0
         anchor_filter = is_in_centers.sum(dim=0) > 0
         geometry_relation = is_in_centers[:, anchor_filter]
-        
+
         return anchor_filter, geometry_relation
 
     def simota_matching(self, cost, pair_wise_ious, gt_classes, num_gt, fg_mask):

--- a/yolox/models/yolo_head.py
+++ b/yolox/models/yolo_head.py
@@ -476,7 +476,7 @@ class YOLOXHead(nn.Module):
                 cls_preds_.float().sigmoid_() * obj_preds_.float().sigmoid_()
             ).sqrt()
             pair_wise_cls_loss = F.binary_cross_entropy(
-                cls_preds_.unsqueeze(0).repeat(num_gt, 1, 1), 
+                cls_preds_.unsqueeze(0).repeat(num_gt, 1, 1),
                 gt_cls_per_image.unsqueeze(1).repeat(1, num_in_boxes_anchor, 1),
                 reduction="none"
             ).sum(-1)

--- a/yolox/models/yolo_head.py
+++ b/yolox/models/yolo_head.py
@@ -537,15 +537,11 @@ class YOLOXHead(nn.Module):
 
         # in fixed center
         center_radius = 1.5
-
-        gt_bboxes_per_image_l = (gt_bboxes_per_image[:, 0]).unsqueeze(1) - \
-            center_radius * expanded_strides_per_image.unsqueeze(0)
-        gt_bboxes_per_image_r = (gt_bboxes_per_image[:, 0]).unsqueeze(1) + \
-            center_radius * expanded_strides_per_image.unsqueeze(0)
-        gt_bboxes_per_image_t = (gt_bboxes_per_image[:, 1]).unsqueeze(1) - \
-            center_radius * expanded_strides_per_image.unsqueeze(0)
-        gt_bboxes_per_image_b = (gt_bboxes_per_image[:, 1]).unsqueeze(1) + \
-            center_radius * expanded_strides_per_image.unsqueeze(0)
+        center_offset = expanded_strides_per_image.unsqueeze(0) * center_radius
+        gt_bboxes_per_image_l = (gt_bboxes_per_image[:, 0:1]) - center_offset
+        gt_bboxes_per_image_r = (gt_bboxes_per_image[:, 0:1]) + center_offset
+        gt_bboxes_per_image_t = (gt_bboxes_per_image[:, 1:2]) - center_offset
+        gt_bboxes_per_image_b = (gt_bboxes_per_image[:, 1:2]) + center_offset
 
         c_l = x_centers_per_image - gt_bboxes_per_image_l
         c_r = gt_bboxes_per_image_r - x_centers_per_image


### PR DESCRIPTION
This PR is tested on YOLOX-tiny and YOLOX-S.

Before (single-node, COCO val set, bs 64):
YOLOX-tiny: 31.6 mAP
YOLOX-small: 40.1 mAP

After (single-node, COCO val set, bs 64):
YOLOX-tiny: 31.6 mAP
YOLOX-small: 40.6 mAP