### PR TITLE
fix iou precision error

### DIFF
--- a/yolox/models/yolo_head.py
+++ b/yolox/models/yolo_head.py
@@ -460,7 +460,7 @@ class YOLOXHead(nn.Module):
             gt_bboxes_per_image = gt_bboxes_per_image.cpu()
             bboxes_preds_per_image = bboxes_preds_per_image.cpu()
 
-        pair_wise_ious = bboxes_iou(gt_bboxes_per_image, bboxes_preds_per_image, False)
+        pair_wise_ious = bboxes_iou(gt_bboxes_per_image.float(), bboxes_preds_per_image.float(), False)
 
         gt_cls_per_image = (
             F.one_hot(gt_classes.to(torch.int64), self.num_classes)


### PR DESCRIPTION
currently, when cal iou, yolox use float16 (in float16 mode), but float16 only has 10 bits for valid part this may lead iou precision error:
for example torch.tensor(841, dtype=float16) -  torch.tensor(5.2, dtype=float16) ==torch.tensor(836., dtype=torch.float16). 

this can lead iou to be larger than 1 and in cls loss, yolox multiplies target with iou, so that the **bce loss can be negtive!**

change iou calculation to float32 seems to fix that
![image](https://user-images.githubusercontent.com/16351543/212294143-83b8a5ce-a4d8-40e1-8cea-aeb28f4ddc7b.png)
![image](https://user-images.githubusercontent.com/16351543/212294686-916a75b7-c0ab-4686-9088-3e8c4622bdb0.png)


