### PR TITLE
Add sequence support for experiment options merge function #1613

### DIFF
--- a/yolox/exp/base_exp.py
+++ b/yolox/exp/base_exp.py
@@ -5,7 +5,7 @@
 import ast
 import pprint
 from abc import ABCMeta, abstractmethod
-from typing import Dict, Sequence
+from typing import Dict, List, Tuple
 from tabulate import tabulate
 
 import torch
@@ -73,8 +73,8 @@ class BaseExp(metaclass=ABCMeta):
                 src_value = getattr(self, k)
                 src_type = type(src_value)
 
-                # pre-process input if source type is a sequence
-                if isinstance(src_value, Sequence):
+                # pre-process input if source type is list or tuple
+                if isinstance(src_value, List) or isinstance(src_value, Tuple):
                     v = v.strip("[]()")
                     v = [t.strip() for t in v.split(",")]
 

--- a/yolox/exp/base_exp.py
+++ b/yolox/exp/base_exp.py
@@ -75,6 +75,7 @@ class BaseExp(metaclass=ABCMeta):
 
                 # pre-process input if source type is a sequence
                 if isinstance(src_value, Sequence):
+                    v = v.strip("[]()")
                     v = [t.strip() for t in v.split(",")]
 
                     # find type of tuple

--- a/yolox/exp/base_exp.py
+++ b/yolox/exp/base_exp.py
@@ -5,7 +5,7 @@
 import ast
 import pprint
 from abc import ABCMeta, abstractmethod
-from typing import Dict
+from typing import Dict, Sequence
 from tabulate import tabulate
 
 import torch
@@ -72,6 +72,16 @@ class BaseExp(metaclass=ABCMeta):
             if hasattr(self, k):
                 src_value = getattr(self, k)
                 src_type = type(src_value)
+
+                # pre-process input if source type is a sequence
+                if isinstance(src_value, Sequence):
+                    v = [t.strip() for t in v.split(",")]
+
+                    # find type of tuple
+                    if len(src_value) > 0:
+                        src_item_type = type(src_value[0])
+                        v = [src_item_type(t) for t in v]
+
                 if src_value is not None and src_type != type(v):
                     try:
                         v = src_type(v)


### PR DESCRIPTION
As mentioned in #1613 tuple and list arguments are not supported by the merge function. This PR adds support for both of them and even converts the values directly into the source format.

Example:

```
python tools/train.py -f myexperiment.py -d 1 -b 64 input_size "512, 512"
```