### PR TITLE
Tweak requirements to not override opencv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # TODO: Update with exact module version
-numpy
-torch>=1.7
-opencv_python
+# numpy
+# torch>=1.7
+# opencv_python
 loguru
 tqdm
 torchvision


### PR DESCRIPTION
Remove opencv, numpy and pytorch from requirements so they aren't overriden