### PR TITLE
Update voc.py

### DIFF
--- a/yolox/data/datasets/voc.py
+++ b/yolox/data/datasets/voc.py
@@ -261,7 +261,7 @@ class VOCDetection(CacheDataset):
                 for im_ind, index in enumerate(self.ids):
                     index = index[1]
                     dets = all_boxes[cls_ind][im_ind]
-                    if dets == []:
+                    if dets.shape[0] == 0:
                         continue
                     for k in range(dets.shape[0]):
                         f.write(


### PR DESCRIPTION
fix bug in _write_voc_results_file. When dets is empty, it will be an array of size (0,5) which will give error if checked against empty list([ ]).