### PR TITLE
Update yolox.cpp: fix INPUT_BLOB_NAME & OUTPUT_BLOB_NAME

### DIFF
--- a/demo/TensorRT/cpp/yolox.cpp
+++ b/demo/TensorRT/cpp/yolox.cpp
@@ -31,8 +31,8 @@ using namespace nvinfer1;
 static const int INPUT_W = 640;
 static const int INPUT_H = 640;
 static const int NUM_CLASSES = 80;
-const char* INPUT_BLOB_NAME = "input_0";
-const char* OUTPUT_BLOB_NAME = "output_0";
+const char* INPUT_BLOB_NAME = "images";
+const char* OUTPUT_BLOB_NAME = "output";
 static Logger gLogger;
 
 cv::Mat static_resize(cv::Mat& img) {


### PR DESCRIPTION
Hi,

This merge request update the name of input & output blob name.
It allow to run tensorrt onnx models converted using `trtexec --onnx=yolox_s.onnx --saveEngine=yolox_s.trt`

Best Regards,
Michel.

