### PR TITLE
Update requirement installation instructions & requirements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ Step1. Install YOLOX from source.
 ```shell
 git clone git@github.com:Megvii-BaseDetection/YOLOX.git
 cd YOLOX
-pip3 install -v -e .  # or  python3 setup.py develop
+pip3 install -U pip setuptools
+pip3 install torch torchvision torchaudio
+pip3 install --no-build-isolation -v -e .  # or  python3 setup.py develop
 ```
 
 </details>

--- a/docs/quick_run.md
+++ b/docs/quick_run.md
@@ -7,8 +7,9 @@ Step1. Install YOLOX.
 ```shell
 git clone git@github.com:Megvii-BaseDetection/YOLOX.git
 cd YOLOX
-pip3 install -U pip && pip3 install -r requirements.txt
-pip3 install -v -e .  # or  python3 setup.py develop
+pip3 install -U pip setuptools
+pip3 install torch torchvision torchaudio
+pip3 install --no-build-isolation -v -e .  # or  python3 setup.py develop
 ```
 Step2. Install [pycocotools](https://github.com/cocodataset/cocoapi).
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ tensorboard
 # pycocotools corresponds to https://github.com/ppwwyyxx/cocoapi
 pycocotools>=2.0.2
 onnx>=1.13.0
-onnx-simplifier==0.4.10
+onnxsim==0.4.13


### PR DESCRIPTION
The current installation instructions don't work. https://github.com/Megvii-BaseDetection/YOLOX/issues/1368#issuecomment-2228159859 provides instructions that work for installing the library requirements. Update the requirement installation instructions so that newcomers can proceed without having to find the issue that includes the new instructions.