### PR TITLE
fix ModuleNotFoundError

### DIFF
--- a/yolox/layers/fast_coco_eval_api.py
+++ b/yolox/layers/fast_coco_eval_api.py
@@ -11,7 +11,7 @@ import time
 import numpy as np
 from pycocotools.cocoeval import COCOeval
 
-from .jit_ops import FastCOCOEvalOp
+from jit_ops import FastCOCOEvalOp
 
 
 class COCOeval_opt(COCOeval):


### PR DESCRIPTION
fix the ModuleNotFoundError: No module named 'yolox.layers.fast_cocoeval' when the cmd is "python -m yolox.tools.eval -n  yolox-nano -c yolox_nano.pth -b 4 --conf 0.001 "