### PR TITLE
fix: Rename `torch.onnx._export` method name.

### DIFF
--- a/tools/export_onnx.py
+++ b/tools/export_onnx.py
@@ -88,7 +88,7 @@ def main():
     logger.info("loading checkpoint done.")
     dummy_input = torch.randn(args.batch_size, 3, exp.test_size[0], exp.test_size[1])
 
-    torch.onnx._export(
+    torch.onnx.export(
         model,
         dummy_input,
         args.output_name,


### PR DESCRIPTION
When we follow the steps to install YOLOX project, the feature to export a pytorch model to onnx is returning the following error:

```python
AttributeError: module 'torch.onnx' has no attribute '_export'
```

In the requirements, the version of Pytorch is setted `>=1.7` therefore the time that this PR is being create, the version that is being installed is `2.5.1`.

And I check in the Pytorch documentation that the correct name is `export` even in the `1.7` version.


**OBS:** Pytorch Documentation Links:
[Pytorch 1.7.0 - torch.onnx.export](https://pytorch.org/docs/1.7.0/onnx.html)

[Pytorch 2.5.0 - torch.onnx.export](https://pytorch.org/docs/2.5/onnx.html)
