### PR TITLE
Changing onnx-simplifier from 0.4.10 version to 0.4.13. Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ tensorboard
 # pycocotools corresponds to https://github.com/ppwwyyxx/cocoapi
 pycocotools>=2.0.2
 onnx>=1.13.0
-onnx-simplifier==0.4.10
+onnx-simplifier==0.4.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ tensorboard
 # pycocotools corresponds to https://github.com/ppwwyyxx/cocoapi
 pycocotools>=2.0.2
 onnx>=1.13.0
-onnx-simplifier==0.4.13
+onnxsim==0.4.13


### PR DESCRIPTION
The `onnx-simplifier` package v0.4.10 has the bug described below. To resolve this issue, updating the package's version from 0.4.10 to 0.4.13 is enough.

The bug:
```bash
Collecting onnx-simplifier==0.4.10 (from yolox==0.3.0)
  Using cached onnx-simplifier-0.4.10.tar.gz (18.1 MB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [34 lines of output]
      /tmp/pip-install-bj3xmkz0/onnx-simplifier_77880a6f94f9493f96d3a520ccb57429/setup.py:26: DeprecationWarning: Use shutil.which instead of find_executable
        CMAKE = find_executable('cmake')
      fatal: not a git repository (or any of the parent directories): .git
      fatal: not a git repository (or any of the parent directories): .git
      /home/pi/Desktop/object_detection_on_rpi/.venv/lib/python3.11/site-packages/setuptools/__init__.py:94: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
      !!
      
              ********************************************************************************
              Requirements should be satisfied by a PEP 517 installer.
              If you are using pip, you can try `pip install --use-pep517`.
              ********************************************************************************
      
      !!
        dist.fetch_build_eggs(dist.setup_requires)
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-bj3xmkz0/onnx-simplifier_77880a6f94f9493f96d3a520ccb57429/setup.py", line 271, in <module>
          setuptools.setup(
        File "/home/pi/Desktop/object_detection_on_rpi/.venv/lib/python3.11/site-packages/setuptools/__init__.py", line 117, in setup
          return distutils.core.setup(**attrs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/pi/Desktop/object_detection_on_rpi/.venv/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 148, in setup
          _setup_distribution = dist = klass(attrs)
                                       ^^^^^^^^^^^^
        File "/home/pi/Desktop/object_detection_on_rpi/.venv/lib/python3.11/site-packages/setuptools/dist.py", line 330, in __init__
          self.metadata.version = self._normalize_version(self.metadata.version)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/pi/Desktop/object_detection_on_rpi/.venv/lib/python3.11/site-packages/setuptools/dist.py", line 366, in _normalize_version
          normalized = str(Version(version))
                           ^^^^^^^^^^^^^^^^
        File "/home/pi/Desktop/object_detection_on_rpi/.venv/lib/python3.11/site-packages/packaging/version.py", line 202, in __init__
          raise InvalidVersion(f"Invalid version: {version!r}")
      packaging.version.InvalidVersion: Invalid version: 'unknown'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```