### PR TITLE
Fix: Preserve 'info' field in COCO-style annotations for compatibility with pycocotools >= 2.0.9

### DIFF
--- a/yolox/data/datasets/coco.py
+++ b/yolox/data/datasets/coco.py
@@ -19,7 +19,6 @@ def remove_useless_info(coco):
     """
     if isinstance(coco, COCO):
         dataset = coco.dataset
-        dataset.pop("info", None)
         dataset.pop("licenses", None)
         for img in dataset["images"]:
             img.pop("license", None)


### PR DESCRIPTION
Since the release of [pycocotools version 2.0.9](https://pypi.org/project/pycocotools/2.0.9/), the loadRes function now requires the 'info' field to be present in the result file. If missing, using COCOEvaluator.evaluate_prediction raises a KeyError: 'info'.

This PR updates the preprocessing step to preserve the 'info' field instead of discarding it, ensuring compatibility with recent versions of pycocotools

PS: this fix is minimal and untested locally but aligns with upstream changes in pycocotools 2.0.9