### PR TITLE
Support grayscale (one-channel) images

### DIFF
--- a/yolox/data/datasets/coco.py
+++ b/yolox/data/datasets/coco.py
@@ -19,7 +19,6 @@ def remove_useless_info(coco):
     """
     if isinstance(coco, COCO):
         dataset = coco.dataset
-        dataset.pop("info", None)
         dataset.pop("licenses", None)
         for img in dataset["images"]:
             img.pop("license", None)
@@ -147,7 +146,7 @@ class COCODataset(CacheDataset):
 
         img_file = os.path.join(self.data_dir, self.name, file_name)
 
-        img = cv2.imread(img_file, cv2.IMREAD_COLOR_BGR if self.num_channels == 3 else cv2.IMREAD_GRAYSCALE)
+        img = cv2.imread(img_file, cv2.IMREAD_COLOR if self.num_channels == 3 else cv2.IMREAD_GRAYSCALE)
         assert img is not None, f"file named {img_file} not found"
 
         return img

--- a/yolox/data/datasets/coco.py
+++ b/yolox/data/datasets/coco.py
@@ -45,6 +45,7 @@ class COCODataset(CacheDataset):
         preproc=None,
         cache=False,
         cache_type="ram",
+        num_channels=3,
     ):
         """
         COCO dataset initialization. Annotation data are read into memory by COCO API.
@@ -71,6 +72,7 @@ class COCODataset(CacheDataset):
         self.img_size = img_size
         self.preproc = preproc
         self.annotations = self._load_coco_annotations()
+        self.num_channels = num_channels
 
         path_filename = [os.path.join(name, anno[3]) for anno in self.annotations]
         super().__init__(
@@ -145,7 +147,7 @@ class COCODataset(CacheDataset):
 
         img_file = os.path.join(self.data_dir, self.name, file_name)
 
-        img = cv2.imread(img_file)
+        img = cv2.imread(img_file, cv2.IMREAD_COLOR_BGR if self.num_channels == 3 else cv2.IMREAD_GRAYSCALE)
         assert img is not None, f"file named {img_file} not found"
 
         return img

--- a/yolox/data/datasets/mosaicdetection.py
+++ b/yolox/data/datasets/mosaicdetection.py
@@ -96,6 +96,8 @@ class MosaicDetection(Dataset):
                 img = cv2.resize(
                     img, (int(w0 * scale), int(h0 * scale)), interpolation=cv2.INTER_LINEAR
                 )
+                if img.ndim == 2:
+                    img = img[:, :, None]
                 # generate output mosaic image
                 (h, w, c) = img.shape[:3]
                 if i_mosaic == 0:

--- a/yolox/data/datasets/mosaicdetection.py
+++ b/yolox/data/datasets/mosaicdetection.py
@@ -191,13 +191,18 @@ class MosaicDetection(Dataset):
         cp_scale_ratio *= jit_factor
 
         if FLIP:
-            cp_img = cp_img[:, ::-1, :]
+            cp_img = cp_img[:, ::-1]
 
         origin_h, origin_w = cp_img.shape[:2]
         target_h, target_w = origin_img.shape[:2]
-        padded_img = np.zeros(
-            (max(origin_h, target_h), max(origin_w, target_w), 3), dtype=np.uint8
-        )
+        if len(img.shape) == 3:
+            padded_img = np.zeros(
+                (max(origin_h, target_h), max(origin_w, target_w), 3), dtype=np.uint8
+            )
+        else:
+            padded_img = np.zeros(
+                (max(origin_h, target_h), max(origin_w, target_w)), dtype=np.uint8
+            )
         padded_img[:origin_h, :origin_w] = cp_img
 
         x_offset, y_offset = 0, 0

--- a/yolox/data/datasets/voc.py
+++ b/yolox/data/datasets/voc.py
@@ -108,6 +108,7 @@ class VOCDetection(CacheDataset):
         dataset_name="VOC0712",
         cache=False,
         cache_type="ram",
+        num_channels=3
     ):
         self.root = data_dir
         self.image_set = image_sets
@@ -131,6 +132,7 @@ class VOCDetection(CacheDataset):
             ):
                 self.ids.append((rootpath, line.strip()))
         self.num_imgs = len(self.ids)
+        self.num_channels = num_channels
 
         self.annotations = self._load_coco_annotations()
 
@@ -184,7 +186,7 @@ class VOCDetection(CacheDataset):
 
     def load_image(self, index):
         img_id = self.ids[index]
-        img = cv2.imread(self._imgpath % img_id, cv2.IMREAD_COLOR)
+        img = cv2.imread(self._imgpath % img_id, cv2.IMREAD_COLOR if self.num_channels == 3 else cv2.IMREAD_GRAYSCALE)
         assert img is not None, f"file named {self._imgpath % img_id} not found"
 
         return img

--- a/yolox/exp/yolox_base.py
+++ b/yolox/exp/yolox_base.py
@@ -32,6 +32,7 @@ class Exp(BaseExp):
         # If your training process cost many memory, reduce this value.
         self.data_num_workers = 4
         self.input_size = (640, 640)  # (height, width)
+        self.num_channels = 3  # 3 for RGB/BGR, 1 for grayscale
         # Actual multiscale ranges: [640 - 5 * 32, 640 + 5 * 32].
         # To disable multiscale training, set the value to 0.
         self.multiscale_range = 5
@@ -52,7 +53,7 @@ class Exp(BaseExp):
         # prob of applying mixup aug
         self.mixup_prob = 1.0
         # prob of applying hsv aug
-        self.hsv_prob = 1.0
+        self.hsv_prob = 1.0 if self.num_channels == 3 else 0.0  # HSV not relevant for grayscale
         # prob of applying flip aug
         self.flip_prob = 0.5
         # rotation angle range, for example, if set to 2, the true range is (-2, 2)
@@ -119,7 +120,7 @@ class Exp(BaseExp):
 
         if getattr(self, "model", None) is None:
             in_channels = [256, 512, 1024]
-            backbone = YOLOPAFPN(self.depth, self.width, in_channels=in_channels, act=self.act)
+            backbone = YOLOPAFPN(self.depth, self.width, in_channels=in_channels, act=self.act, num_channels=self.num_channels)
             head = YOLOXHead(self.num_classes, self.width, in_channels=in_channels, act=self.act)
             self.model = YOLOX(backbone, head)
 

--- a/yolox/exp/yolox_base.py
+++ b/yolox/exp/yolox_base.py
@@ -46,6 +46,10 @@ class Exp(BaseExp):
         self.val_ann = "instances_val2017.json"
         # name of annotation file for testing
         self.test_ann = "instances_test2017.json"
+        # name of image folders for training, evaluation and testing
+        self.train_name = "train2017"
+        self.val_name = "val2017"
+        self.test_name = "test2017"
 
         # --------------- transform config ----------------- #
         # prob of applying mosaic aug
@@ -151,6 +155,8 @@ class Exp(BaseExp):
             ),
             cache=cache,
             cache_type=cache_type,
+            name=self.train_name,
+            num_channels=self.num_channels,
         )
 
     def get_data_loader(self, batch_size, is_distributed, no_aug=False, cache_img: str = None):
@@ -305,9 +311,10 @@ class Exp(BaseExp):
         return COCODataset(
             data_dir=self.data_dir,
             json_file=self.val_ann if not testdev else self.test_ann,
-            name="val2017" if not testdev else "test2017",
+            name=self.val_name if not testdev else self.test_name,
             img_size=self.test_size,
             preproc=ValTransform(legacy=legacy),
+            num_channels=self.num_channels,
         )
 
     def get_eval_loader(self, batch_size, is_distributed, **kwargs):

--- a/yolox/models/darknet.py
+++ b/yolox/models/darknet.py
@@ -102,6 +102,7 @@ class CSPDarknet(nn.Module):
         out_features=("dark3", "dark4", "dark5"),
         depthwise=False,
         act="silu",
+        num_channels=3,
     ):
         super().__init__()
         assert out_features, "please provide output features of Darknet"
@@ -112,7 +113,7 @@ class CSPDarknet(nn.Module):
         base_depth = max(round(dep_mul * 3), 1)  # 3
 
         # stem
-        self.stem = Focus(3, base_channels, ksize=3, act=act)
+        self.stem = Focus(num_channels, base_channels, ksize=3, act=act)
 
         # dark2
         self.dark2 = nn.Sequential(

--- a/yolox/models/yolo_pafpn.py
+++ b/yolox/models/yolo_pafpn.py
@@ -22,9 +22,10 @@ class YOLOPAFPN(nn.Module):
         in_channels=[256, 512, 1024],
         depthwise=False,
         act="silu",
+        num_channels=3,
     ):
         super().__init__()
-        self.backbone = CSPDarknet(depth, width, depthwise=depthwise, act=act)
+        self.backbone = CSPDarknet(depth, width, depthwise=depthwise, act=act, num_channels=num_channels)
         self.in_features = in_features
         self.in_channels = in_channels
         Conv = DWConv if depthwise else BaseConv

--- a/yolox/utils/model_utils.py
+++ b/yolox/utils/model_utils.py
@@ -23,7 +23,8 @@ def get_model_info(model: nn.Module, tsize: Sequence[int]) -> str:
     from thop import profile
 
     stride = 64
-    img = torch.zeros((1, 3, stride, stride), device=next(model.parameters()).device)
+    in_channels = model.backbone.backbone.stem.conv.conv.in_channels // 4
+    img = torch.zeros((1, in_channels, stride, stride), device=next(model.parameters()).device)
     flops, params = profile(deepcopy(model), inputs=(img,), verbose=False)
     params /= 1e6
     flops /= 1e9


### PR DESCRIPTION
By specifying num_channels = 1 in the experiment file (instead of the default 3), these changes support training with grayscale images:

- num_channels parameter in COCO and VOC dataset classes with adapted load_img function, which reads grayscale images if num_channels == 1
- Focus in stem of backbone allows for in_channels to be 1 instead of being hard-coded to 3
- model_info in model_utils adapts img to fit the in_channels of the stem of the backbone
- data augmentation / mosaic detection files allow for channel dimension to be absent

Apart from these specific changes to support the main goal of this PR (to allow grayscale images directly), there are two minor modifications:
- in coco dataset do not remove the info field in the remove_useless_info function. In the pycocotools version 2.0.9 (and subsequent ones) in the loadRes function this line was added 
 res.dataset['info'] = copy.deepcopy(self.dataset['info'])
 which leads to a KeyError in the evaluation, if the info field is missing
 - specify the name parameter in the get_dataset and get_eval_dataset in the Experiment class in yolox_base.py to allow classes, which inherit this experiment class, to easily specify a custom image folder (e.g. by overwriting self.test_name in the __init__ function)